### PR TITLE
fix: clean up timeout handles in MCP client

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,5 +27,8 @@
         "docker-compose.yml": "docker-compose.*.yml",
         "README.md": "README.*.md,README-*.md,README_*.md"
     },
-    "markdown.validate.enabled": true
+    "markdown.validate.enabled": true,
+    "lanonasis.showPerformanceFeedback": true,
+    "lanonasis.showTreeView": true,
+    "lanonasis.verboseLogging": true
 }


### PR DESCRIPTION
## Follow-up to PR #54

This PR addresses the remaining review comment from PR #54 about properly cleaning up timeout handles.

### Changes
- Clear timeout handles after Promise.race completes in both `connect()` and `callTool()` methods
- Prevents potential memory leaks from uncleaned timers
- Uses try/finally blocks to ensure cleanup happens even on errors

### Testing
- ✅ All existing tests pass
- ✅ No functional changes, only cleanup improvements

### Context
This was suggested by CodeRabbit in the original PR review:
> The `setTimeout` calls in the timeout promises create timer handles that aren't explicitly cleared when the race completes successfully. While modern JavaScript engines handle this, explicitly clearing timeouts is cleaner.

cc: @coderabbitai

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clears timeout handles in `MCPClient` for `connect()` and `callTool()`; enables LanonaSis VS Code settings.
> 
> - **REPL CLI**:
>   - **`MCPClient` timeout cleanup**:
>     - Store timeout handles and clear them in `finally` for `connect()` and `callTool()` to avoid lingering timers.
> - **Editor Config**:
>   - Enable `lanonasis.showPerformanceFeedback`, `lanonasis.showTreeView`, and `lanonasis.verboseLogging` in `.vscode/settings.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6db0a82f76aa2d755be987df72cc7b564c324a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New configuration options available to enable performance feedback, tree view display, and verbose logging for enhanced visibility and debugging capabilities.

* **Bug Fixes**
  * Enhanced timer cleanup mechanisms to prevent resource leaks during operations, improving overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->