### PR TITLE
fix(cli): align api-keys & projects endpoint paths to server routing

### DIFF
--- a/cli/src/commands/api-keys.ts
+++ b/cli/src/commands/api-keys.ts
@@ -17,8 +17,8 @@ const colors = {
   highlight: chalk.white.bold
 };
 
-const AUTH_API_KEYS_BASE = '/api/v1/auth/api-keys';
-const PROJECTS_API_BASE = '/api/v1/projects';
+const AUTH_API_KEYS_BASE = '/api/v1/api-keys';
+const PROJECTS_API_BASE = '/api/v1/api-keys/projects';
 const VALID_ACCESS_LEVELS = ['public', 'authenticated', 'team', 'admin', 'enterprise'] as const;
 const VALID_KEY_CONTEXTS = ['personal', 'team', 'enterprise'] as const;
 type ApiKeyContext = typeof VALID_KEY_CONTEXTS[number];


### PR DESCRIPTION
## Summary

Re-applies the intent of [PR #100](https://github.com/lanonasis/lanonasis-maas/pull/100) (`claude/slack-session-BwqNa`, closed without merging) as a minimal-diff fix on top of the current `main`.

The CLI `api-keys` command was hitting:
- `/api/v1/auth/api-keys` → **404** (no such route is mounted)
- `/api/v1/projects` → **404** (no such route is mounted)

Actual server routing (verified at `src/server.ts:288` and `src/routes/api-keys.ts:214,282`):
- `app.use('/api/v1/api-keys', apiKeyRoutes)` — top-level mount
- `router.post('/projects', ...)` and `router.get('/projects', ...)` inside `apiKeyRoutes` → effective path `/api/v1/api-keys/projects`

So both CLI constants needed correction:

```diff
-const AUTH_API_KEYS_BASE = '/api/v1/auth/api-keys';
-const PROJECTS_API_BASE = '/api/v1/projects';
+const AUTH_API_KEYS_BASE = '/api/v1/api-keys';
+const PROJECTS_API_BASE = '/api/v1/api-keys/projects';
```

All 16 endpoint call sites in `cli/src/commands/api-keys.ts` go through these constants, so a 2-line constant change cascades.

## Why not cherry-pick PR #100 directly?

The original `082d5e6a` cherry-pick produced merge conflicts because `main` has since gained the `unwrapApiResponse` helper, `PlatformApiKey` types, and other structural pieces that the slack-session diff also touched. After abort and inspection, all the helpers PR #100 was adding now live on `main` already — the only remaining drift is the path values themselves. Two-line fix is cleaner than a 100-line conflict resolution that produces the same runtime behavior.

The companion doc `docs/cli-drift-analysis-and-fixes.md` is already on `main` with the analysis but **not** with the fix it described — this PR closes that gap.

## Test plan

- [ ] `memory api-keys list` no longer returns 404
- [ ] `memory api-keys create --name foo --service test` lands at `/api/v1/api-keys` and returns the persisted key
- [ ] `memory api-keys projects list` lands at `/api/v1/api-keys/projects`
- [ ] CLI build (`npm run build` in `cli/`) typechecks