### PR TITLE
fix(memory-client): mark tsconfig as composite for project references

### DIFF
--- a/packages/memory-client/tsconfig.json
+++ b/packages/memory-client/tsconfig.json
@@ -23,6 +23,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
+    "composite": true,
     "types": [
       "node"
     ]


### PR DESCRIPTION
## Summary

The root \`tsconfig.json\` declares \`packages/memory-client\` in its \`references\` array (alongside \`lanonasis-sdk\` and \`memory-engine\`, which both already have \`\"composite\": true\`). Without the same setting on \`memory-client\`, project-references-aware TypeScript commands fail:

\`\`\`
tsconfig.json(47,5): error TS6306: Referenced project
'/.../packages/memory-client' must have setting "composite": true.
\`\`\`

This is the minimal fix — a one-line change that aligns \`memory-client\` with its two sibling referenced packages and unblocks workspace-level \`tsc --noEmit\`.

## Why composite (vs removing the reference)

- \`lanonasis-sdk\` and \`memory-engine\` are already composite, so the convention is established.
- Removing the reference would also work but loses the project-graph guarantees (incremental builds, declaration emit ordering).
- This change has no impact on emitted JS, declaration shape, or downstream consumers — \`composite: true\` is purely a TS project-graph signal.

## Verification

Before:
\`\`\`
tsconfig.json(47,5): error TS6306: Referenced project '.../packages/memory-client' must have setting "composite": true.
\`\`\`

After:
- TS6306 is gone.
- All remaining \`tsc --noEmit\` failures are pre-existing, unrelated type issues in \`src/middleware/centralAuth.ts\`, \`src/routes/api-keys.ts\`, \`src/routes/memory.ts\`, \`src/services/memoryService.ts\` — out of scope for this PR.

## Test plan

- [ ] CI \`Verify Package\` job passes (\`bunx nx run @lanonasis/memory-client:typecheck\` and the package-local build).
- [ ] No change in published \`@lanonasis/memory-client\` build output (rollup config is unaffected).
- [ ] Confirm no consumer breakage downstream — composite only affects TS project graph metadata.

## Follow-up

After this lands, the parent monorepo (\`thefixer3x/lan-onasis-monorepo\`) should bump the \`apps/lanonasis-maas\` submodule pointer in a separate PR to pick up this commit. Doing it as a separate change so the submodule fix is reviewable in isolation.