### PR TITLE
fix: resolve PR106/107 review findings — org scope, logging, Zod validation

### DIFF
--- a/packages/repl-cli/src/commands/memory-commands.ts
+++ b/packages/repl-cli/src/commands/memory-commands.ts
@@ -491,16 +491,16 @@ export class MemoryCommands {
       console.log(chalk.cyan('\nProfile Summary:'), p.profile_summary ?? chalk.gray('(none)'));
       console.log(chalk.cyan('\nStructured Fields:'));
       for (const [field, items] of Object.entries(p.structured_fields ?? {})) {
-        if ((items as string[]).length > 0) {
+        if (items.length > 0) {
           console.log(chalk.bold(`  ${field}:`));
-          for (const item of items as string[]) {
+          for (const item of items) {
             console.log(chalk.gray(`    • ${item}`));
           }
         }
       }
       console.log(chalk.cyan('\nConfidence by Field:'));
       for (const [field, score] of Object.entries(p.confidence_by_field ?? {})) {
-        console.log(chalk.gray(`  ${field}: ${(score as number).toFixed(2)}`));
+        console.log(chalk.gray(`  ${field}: ${score.toFixed(2)}`));
       }
       console.log(chalk.dim(`\nFreshness: ${p.freshness} | Updated: ${p.updated_at}`));
       context.lastResult = p;

--- a/src/routes/profiles.ts
+++ b/src/routes/profiles.ts
@@ -7,15 +7,18 @@ import {
   validateProjectScope,
 } from '@/middleware/auth-aligned';
 import { logger } from '@/utils/logger';
+import { metrics } from '@/utils/metrics';
 import { ProfileService } from '@/services/profileService';
 import {
   resolveIntelligenceSubjectBoundary,
-  canReadIntelligenceSubject,
 } from '@/services/intelligenceAccess';
 
 const profileParamsSchema = z.object({ subject_id: z.string().uuid() });
 const profileVersionsQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+const profileAskBodySchema = z.object({
+  question: z.string().trim().min(1, 'question is required'),
 });
 
 const router: Router = Router();
@@ -30,8 +33,10 @@ router.get(
   alignedAuthMiddleware,
   planBasedRateLimit('intelligence'),
   asyncHandler(async (req: Request, res: Response) => {
+    const startTime = Date.now();
     const parsedParams = profileParamsSchema.safeParse(req.params);
     if (!parsedParams.success) {
+      metrics.incrementCounter('profiles.get.total', { outcome: 'validation_error' }, 1);
       res.status(400).json({ error: 'Validation failed', details: parsedParams.error.issues });
       return;
     }
@@ -40,6 +45,7 @@ router.get(
     const boundary = resolveIntelligenceSubjectBoundary(req.user, subject_id);
     if (!boundary) {
       logger.warn('profiles.get: subject outside visibility boundary', { subject_id, user: req.user?.id });
+      metrics.incrementCounter('profiles.get.total', { outcome: 'forbidden' }, 1);
       res.status(403).json({ error: 'Subject is outside the authenticated visibility boundary' });
       return;
     }
@@ -50,11 +56,14 @@ router.get(
     const profile = await profileService.getProfile(boundary.subjectId, orgScope);
     if (!profile) {
       logger.info('profiles.get: profile not found', { subject_id: boundary.subjectId });
+      metrics.incrementCounter('profiles.get.total', { outcome: 'not_found' }, 1);
       res.status(404).json({ error: 'Profile not found' });
       return;
     }
 
     logger.info('profiles.get: retrieved', { subject_id: boundary.subjectId });
+    metrics.incrementCounter('profiles.get.total', { outcome: 'success' }, 1);
+    metrics.recordDuration('profiles.get.duration', Date.now() - startTime, {});
     res.json({ profile });
   }),
 );
@@ -69,13 +78,16 @@ router.get(
   alignedAuthMiddleware,
   planBasedRateLimit('intelligence'),
   asyncHandler(async (req: Request, res: Response) => {
+    const startTime = Date.now();
     const parsedParams = profileParamsSchema.safeParse(req.params);
     if (!parsedParams.success) {
+      metrics.incrementCounter('profiles.versions.total', { outcome: 'validation_error' }, 1);
       res.status(400).json({ error: 'Validation failed', details: parsedParams.error.issues });
       return;
     }
     const parsedQuery = profileVersionsQuerySchema.safeParse(req.query);
     if (!parsedQuery.success) {
+      metrics.incrementCounter('profiles.versions.total', { outcome: 'validation_error' }, 1);
       res.status(400).json({ error: 'Validation failed', details: parsedQuery.error.issues });
       return;
     }
@@ -83,14 +95,19 @@ router.get(
     const { subject_id } = parsedParams.data;
     const { limit } = parsedQuery.data;
 
-    if (!canReadIntelligenceSubject(req.user, subject_id)) {
+    const boundary = resolveIntelligenceSubjectBoundary(req.user, subject_id);
+    if (!boundary) {
       logger.warn('profiles.versions: access denied', { subject_id, user: req.user?.id });
+      metrics.incrementCounter('profiles.versions.total', { outcome: 'forbidden' }, 1);
       res.status(403).json({ error: 'Subject is outside the authenticated visibility boundary' });
       return;
     }
 
+    const orgScope = boundary.personalSubject ? undefined : boundary.organizationId;
     logger.info('profiles.versions: fetching', { subject_id, limit });
-    const versions = await profileService.getProfileHistory(subject_id, limit);
+    const versions = await profileService.getProfileHistory(subject_id, limit, orgScope);
+    metrics.incrementCounter('profiles.versions.total', { outcome: 'success' }, 1);
+    metrics.recordDuration('profiles.versions.duration', Date.now() - startTime, {});
     res.json({ versions });
   }),
 );
@@ -105,29 +122,35 @@ router.post(
   alignedAuthMiddleware,
   planBasedRateLimit('intelligence'),
   asyncHandler(async (req: Request, res: Response) => {
+    const startTime = Date.now();
     const parsedParams = profileParamsSchema.safeParse(req.params);
     if (!parsedParams.success) {
+      metrics.incrementCounter('profiles.ask.total', { outcome: 'validation_error' }, 1);
       res.status(400).json({ error: 'Validation failed', details: parsedParams.error.issues });
       return;
     }
 
     const { subject_id } = parsedParams.data;
-    const { question } = req.body as { question?: string };
-
-    if (!question || typeof question !== 'string') {
-      res.status(400).json({ error: 'question is required' });
+    const parsedBody = profileAskBodySchema.safeParse(req.body);
+    if (!parsedBody.success) {
+      metrics.incrementCounter('profiles.ask.total', { outcome: 'validation_error' }, 1);
+      res.status(400).json({ error: 'Validation failed', details: parsedBody.error.issues });
       return;
     }
 
+    const { question } = parsedBody.data;
     const boundary = resolveIntelligenceSubjectBoundary(req.user, subject_id);
     if (!boundary) {
       logger.warn('profiles.ask: subject outside visibility boundary', { subject_id, user: req.user?.id });
+      metrics.incrementCounter('profiles.ask.total', { outcome: 'forbidden' }, 1);
       res.status(403).json({ error: 'Subject is outside the authenticated visibility boundary' });
       return;
     }
 
     logger.info('profiles.ask: querying', { subject_id: boundary.subjectId, question_length: question.length });
     const result = await profileService.askProfile(boundary.subjectId, question);
+    metrics.incrementCounter('profiles.ask.total', { outcome: 'success' }, 1);
+    metrics.recordDuration('profiles.ask.duration', Date.now() - startTime, {});
     res.json(result);
   }),
 );

--- a/src/routes/profiles.ts
+++ b/src/routes/profiles.ts
@@ -1,15 +1,22 @@
 import { Router, Request, Response } from 'express';
+import { z } from 'zod';
 import { asyncHandler } from '@/middleware/errorHandler';
 import {
   alignedAuthMiddleware,
   planBasedRateLimit,
   validateProjectScope,
 } from '@/middleware/auth-aligned';
+import { logger } from '@/utils/logger';
 import { ProfileService } from '@/services/profileService';
 import {
   resolveIntelligenceSubjectBoundary,
   canReadIntelligenceSubject,
 } from '@/services/intelligenceAccess';
+
+const profileParamsSchema = z.object({ subject_id: z.string().uuid() });
+const profileVersionsQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
 
 const router: Router = Router();
 const profileService = new ProfileService();
@@ -23,18 +30,31 @@ router.get(
   alignedAuthMiddleware,
   planBasedRateLimit('intelligence'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { subject_id } = req.params;
+    const parsedParams = profileParamsSchema.safeParse(req.params);
+    if (!parsedParams.success) {
+      res.status(400).json({ error: 'Validation failed', details: parsedParams.error.issues });
+      return;
+    }
+
+    const { subject_id } = parsedParams.data;
     const boundary = resolveIntelligenceSubjectBoundary(req.user, subject_id);
     if (!boundary) {
+      logger.warn('profiles.get: subject outside visibility boundary', { subject_id, user: req.user?.id });
       res.status(403).json({ error: 'Subject is outside the authenticated visibility boundary' });
       return;
     }
 
-    const profile = await profileService.getProfile(boundary.subjectId);
+    // Pass organization_id for non-personal subjects so the service-role query
+    // is constrained to the caller's org and cannot read cross-tenant profiles.
+    const orgScope = boundary.personalSubject ? undefined : boundary.organizationId;
+    const profile = await profileService.getProfile(boundary.subjectId, orgScope);
     if (!profile) {
+      logger.info('profiles.get: profile not found', { subject_id: boundary.subjectId });
       res.status(404).json({ error: 'Profile not found' });
       return;
     }
+
+    logger.info('profiles.get: retrieved', { subject_id: boundary.subjectId });
     res.json({ profile });
   }),
 );
@@ -49,14 +69,27 @@ router.get(
   alignedAuthMiddleware,
   planBasedRateLimit('intelligence'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { subject_id } = req.params;
-    const limit = Math.min(parseInt(req.query.limit as string) || 20, 100);
+    const parsedParams = profileParamsSchema.safeParse(req.params);
+    if (!parsedParams.success) {
+      res.status(400).json({ error: 'Validation failed', details: parsedParams.error.issues });
+      return;
+    }
+    const parsedQuery = profileVersionsQuerySchema.safeParse(req.query);
+    if (!parsedQuery.success) {
+      res.status(400).json({ error: 'Validation failed', details: parsedQuery.error.issues });
+      return;
+    }
+
+    const { subject_id } = parsedParams.data;
+    const { limit } = parsedQuery.data;
 
     if (!canReadIntelligenceSubject(req.user, subject_id)) {
+      logger.warn('profiles.versions: access denied', { subject_id, user: req.user?.id });
       res.status(403).json({ error: 'Subject is outside the authenticated visibility boundary' });
       return;
     }
 
+    logger.info('profiles.versions: fetching', { subject_id, limit });
     const versions = await profileService.getProfileHistory(subject_id, limit);
     res.json({ versions });
   }),
@@ -72,7 +105,13 @@ router.post(
   alignedAuthMiddleware,
   planBasedRateLimit('intelligence'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { subject_id } = req.params;
+    const parsedParams = profileParamsSchema.safeParse(req.params);
+    if (!parsedParams.success) {
+      res.status(400).json({ error: 'Validation failed', details: parsedParams.error.issues });
+      return;
+    }
+
+    const { subject_id } = parsedParams.data;
     const { question } = req.body as { question?: string };
 
     if (!question || typeof question !== 'string') {
@@ -82,10 +121,12 @@ router.post(
 
     const boundary = resolveIntelligenceSubjectBoundary(req.user, subject_id);
     if (!boundary) {
+      logger.warn('profiles.ask: subject outside visibility boundary', { subject_id, user: req.user?.id });
       res.status(403).json({ error: 'Subject is outside the authenticated visibility boundary' });
       return;
     }
 
+    logger.info('profiles.ask: querying', { subject_id: boundary.subjectId, question_length: question.length });
     const result = await profileService.askProfile(boundary.subjectId, question);
     res.json(result);
   }),

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -85,15 +85,22 @@ export class ProfileService {
 
   /**
    * Get a memory profile for a subject.
+   * When organization_id is provided the query also filters by it, preventing
+   * cross-tenant reads when the service-role client bypasses RLS.
    */
-  async getProfile(subject_id: string): Promise<MemoryProfile | null> {
+  async getProfile(subject_id: string, organization_id?: string): Promise<MemoryProfile | null> {
     const startTime = Date.now();
 
-    const { data, error } = await this.supabase
+    let query = this.supabase
       .from('memory_profiles')
       .select('*')
-      .eq('subject_id', subject_id)
-      .single();
+      .eq('subject_id', subject_id);
+
+    if (organization_id) {
+      query = query.eq('organization_id', organization_id);
+    }
+
+    const { data, error } = await query.single();
 
     if (error) {
       if (error.code === 'PGRST116') {

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -104,6 +104,8 @@ export class ProfileService {
 
     if (error) {
       if (error.code === 'PGRST116') {
+        this.metrics.incrementCounter('profile.get.not_found', {}, 1);
+        this.metrics.recordDuration('profile.get.duration', Date.now() - startTime, { outcome: 'not_found' });
         logger.info('getProfile profile not found', { subject_id });
         return null;
       }
@@ -124,10 +126,25 @@ export class ProfileService {
 
   /**
    * Get version history for a profile.
-   * Note: subject_id param is used for profile_id column in DB.
+   * When organization_id is provided, a preliminary check verifies the parent
+   * profile belongs to that org (memory_profile_versions has no org column).
    */
-  async getProfileHistory(subject_id: string, limit = 20): Promise<ProfileVersion[]> {
+  async getProfileHistory(subject_id: string, limit = 20, organization_id?: string): Promise<ProfileVersion[]> {
     const startTime = Date.now();
+
+    if (organization_id) {
+      const { data: profileCheck } = await this.supabase
+        .from('memory_profiles')
+        .select('subject_id')
+        .eq('subject_id', subject_id)
+        .eq('organization_id', organization_id)
+        .single();
+      if (!profileCheck) {
+        this.metrics.incrementCounter('profile.history.not_found', {}, 1);
+        logger.info('getProfileHistory: profile not found under org', { subject_id });
+        return [];
+      }
+    }
 
     const { data, error } = await this.supabase
       .from('memory_profile_versions')


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Addresses all actionable findings from the Codex and CodeRabbit reviews on PR #106 and PR #107. Items already resolved in those PRs are noted below as skipped.

## What changed

### Security fix (Codex P1 — cross-tenant profile read)
- `profileService.getProfile()` now accepts an optional `organization_id` parameter; when supplied, the Supabase query also filters `.eq('organization_id', ...)`, preventing the service-role client from returning records owned by a different tenant even when a caller guesses the correct `subject_id` UUID
- `src/routes/profiles.ts` GET `/:subject_id` passes `boundary.organizationId` for non-personal subject accesses, closing the cross-tenant read vector

### Input validation (CodeRabbit)
- Added `profileParamsSchema` (`z.object({ subject_id: z.string().uuid() })`) and `profileVersionsQuerySchema` (with `z.coerce.number().int().min(1).max(100).default(20)`) to `profiles.ts`
- All three route handlers now `safeParse` their params/query and return structured 400s on failure, replacing the previous manual `parseInt` and bare param reads

### Structured logging (CodeRabbit)
- Imported shared Winston `logger` in `profiles.ts`
- Added `logger.warn` on boundary-denial paths and `logger.info` on successful retrievals in all three handlers

### Type cast cleanup (CodeRabbit)
- Removed redundant `as string[]` and `as number` casts in the CLI `profileShow` command — `MemoryProfile.structured_fields` and `confidence_by_field` are already correctly typed

## Skipped (already resolved in merged PRs)

| Finding | Status |
|---|---|
| Middleware imports from non-existent modules | Fixed in PR #106/107 — both routes already use `@/middleware/auth-aligned` |
| SDK job envelope mismatch (`result.data.job`) | Fixed — `getReasoningJobStatus` in client.ts correctly unwraps `result.data.job` |
| `conclusions job <job-id>` CLI routing | Fixed — `repl-engine.ts` correctly dispatches to `getJobStatus` |
| Winston logger in `intelligence.ts` | Fixed — all handlers use `logger.error/warn/info` |
| Prometheus metrics in service methods | Fixed — `intelligenceService.ts` and `profileService.ts` fully instrumented |
| Zod validation in `intelligence.ts` | Fixed — `conclusionsQuerySchema` and `flushRequestSchema` present |
| `(c as any)` casts for `InferredConclusion` fields | Fixed — `conclusion_type`, `confidence`, `content` already typed correctly |

## Test plan

- [ ] `GET /api/v1/profiles/:subject_id` with a valid token for org user + guessed cross-tenant UUID returns 404 (profile not found) rather than leaking the record
- [ ] Same route with invalid UUID format returns 400 with Zod error details
- [ ] `GET /api/v1/profiles/:subject_id/versions?limit=abc` returns 400
- [ ] `POST /api/v1/profiles/:subject_id/ask` with invalid UUID returns 400
- [ ] Personal subject access (userId === subject_id) continues to work without org filter

https://claude.ai/code/session_01YbWimVw9DRXAhuP146bdeN
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbWimVw9DRXAhuP146bdeN)_