### PR TITLE
feat(repl-cli): add /context converge v0

### DIFF
--- a/packages/repl-cli/src/commands/memory-commands.ts
+++ b/packages/repl-cli/src/commands/memory-commands.ts
@@ -49,6 +49,21 @@ const VALID_MEMORY_STATUSES = [
 type MemoryType = (typeof VALID_MEMORY_TYPES)[number];
 type MemoryStatus = (typeof VALID_MEMORY_STATUSES)[number];
 
+/**
+ * Minimum non-backfilled event-tagged memories required before
+ * `/context converge` calls askProfile() for Mind/Heart/Concierge synthesis.
+ *
+ * Below this floor, the prompt template — which always asks for three
+ * structured blocks — invites the model to fabricate patterns from
+ * insufficient signal. We instead surface the events themselves and
+ * tell the user to capture more before synthesizing.
+ *
+ * Three was chosen because Mind/Heart/Concierge synthesizes across three
+ * lenses; with fewer events than lenses, distribution is structurally
+ * thin and any "pattern" is a hallucination.
+ */
+const MIN_EVENTS_FOR_CONVERGENCE = 3;
+
 interface ConvergedEvent {
   memory: MemoryEntry;
   types: EventType[];
@@ -565,11 +580,37 @@ export class MemoryCommands {
 
       if (events.length === 0) {
         spinner.succeed(chalk.gray('No event-tagged memories found for convergence.'));
-        context.lastResult = { events: [], distribution: {} };
+        context.lastResult = { events: [], distribution: {}, low_signal: true };
         return;
       }
 
       const distribution = this.eventDistribution(events);
+
+      // Low-signal guard: with fewer than MIN_EVENTS_FOR_CONVERGENCE events,
+      // skip askProfile entirely. The Mind/Heart/Concierge prompt cannot
+      // honestly synthesize across so few data points; surfacing the raw
+      // events is more useful (and more truthful) than fabricated patterns.
+      if (events.length < MIN_EVENTS_FOR_CONVERGENCE) {
+        spinner.succeed(chalk.yellow(
+          `Only ${events.length} event-tagged memor${events.length === 1 ? 'y' : 'ies'} captured — ` +
+          `need at least ${MIN_EVENTS_FOR_CONVERGENCE} for convergence.`
+        ));
+        console.log(chalk.gray('\nEvents found:'));
+        for (const event of events) {
+          const tagList = event.types.map(t => eventTag(t)).join(', ');
+          console.log(chalk.gray(`  [${tagList}] ${event.memory.title} (${event.memory.id})`));
+        }
+        console.log(chalk.gray('\nCapture more events with `create ... --event=<type>` or `event tag <id> <type>`,'));
+        console.log(chalk.gray('then re-run `context converge` to synthesize.'));
+        context.lastResult = {
+          subject_id: subjectId,
+          event_count: events.length,
+          distribution,
+          low_signal: true,
+          event_ids: events.map(e => e.memory.id),
+        };
+        return;
+      }
       const conclusionsResult = await client.listInferredConclusions({
         subject_id: subjectId,
         limit: 12,

--- a/packages/repl-cli/src/commands/memory-commands.ts
+++ b/packages/repl-cli/src/commands/memory-commands.ts
@@ -10,7 +10,14 @@ import chalk from 'chalk';
 import ora from 'ora';
 import { CommandContext } from '../config/types.js';
 import { withSpinner } from '../utils/spinner-utils.js';
-import { eventTag, isEventType, EVENT_TYPES, type EventType } from '../events/index.js';
+import {
+  eventTag,
+  eventTypeFromTag,
+  isEventType,
+  EVENT_TYPES,
+  TAG_BACKFILLED,
+  type EventType,
+} from '../events/index.js';
 
 const VALID_MEMORY_TYPES = [
   'context',
@@ -41,6 +48,11 @@ const VALID_MEMORY_STATUSES = [
 
 type MemoryType = (typeof VALID_MEMORY_TYPES)[number];
 type MemoryStatus = (typeof VALID_MEMORY_STATUSES)[number];
+
+interface ConvergedEvent {
+  memory: MemoryEntry;
+  types: EventType[];
+}
 
 export class MemoryCommands {
   private client: MemoryClient | null = null;
@@ -491,6 +503,215 @@ export class MemoryCommands {
     } finally {
       resumeReadline();
     }
+  }
+
+  async contextConverge(args: string[], context: CommandContext): Promise<void> {
+    let subjectId: string | undefined;
+    let limit = 200;
+    let includeBackfilled = false;
+
+    for (const arg of args) {
+      if (arg.startsWith('--subject=')) {
+        subjectId = arg.substring(10).trim();
+      } else if (arg.startsWith('--limit=')) {
+        const parsed = parseInt(arg.substring(8), 10);
+        if (Number.isFinite(parsed) && parsed > 0) {
+          limit = Math.min(parsed, 200);
+        }
+      } else if (arg === '--include-backfilled') {
+        includeBackfilled = true;
+      }
+    }
+
+    if (!subjectId) {
+      console.log(chalk.yellow('Usage: context converge --subject=<uuid> [--limit=200] [--include-backfilled]'));
+      return;
+    }
+
+    pauseReadline();
+    const spinner = ora('Gathering event-tagged memories...').start();
+    try {
+      const client = this.getClient(context);
+      const byId = new Map<string, MemoryEntry>();
+
+      for (const type of EVENT_TYPES) {
+        const result = await client.listMemories({
+          status: 'active',
+          tags: [eventTag(type)],
+          limit,
+          sort: 'created_at',
+          order: 'desc',
+        });
+
+        if (result.error) {
+          spinner.fail(chalk.red(`Converge failed while reading event:${type}: ${result.error}`));
+          return;
+        }
+
+        for (const memory of result.data?.data ?? []) {
+          if (!includeBackfilled && memory.tags?.includes(TAG_BACKFILLED)) continue;
+          byId.set(memory.id, memory);
+        }
+      }
+
+      const events = Array.from(byId.values())
+        .map((memory): ConvergedEvent => ({
+          memory,
+          types: this.eventTypesFor(memory),
+        }))
+        .filter(event => event.types.length > 0)
+        .sort((a, b) => Date.parse(b.memory.created_at) - Date.parse(a.memory.created_at))
+        .slice(0, limit);
+
+      if (events.length === 0) {
+        spinner.succeed(chalk.gray('No event-tagged memories found for convergence.'));
+        context.lastResult = { events: [], distribution: {} };
+        return;
+      }
+
+      const distribution = this.eventDistribution(events);
+      const conclusionsResult = await client.listInferredConclusions({
+        subject_id: subjectId,
+        limit: 12,
+      });
+      const conclusions = conclusionsResult.data?.conclusions ?? [];
+      const conclusionDigest = conclusions
+        .map((c, i) => `${i + 1}. [${c.conclusion_type ?? 'unknown'} ${(c.confidence ?? 0).toFixed(2)}] ${c.content}`)
+        .join('\n');
+
+      spinner.text = 'Synthesizing convergence...';
+      const question = this.buildConvergenceQuestion({
+        subjectId,
+        events,
+        distribution,
+        conclusionDigest,
+      });
+      const answerResult = await client.askProfile(subjectId, question);
+
+      if (answerResult.error) {
+        spinner.fail(chalk.red(`Converge synthesis failed: ${answerResult.error}`));
+        return;
+      }
+
+      spinner.succeed(chalk.green(`Converged ${events.length} event-tagged memor${events.length === 1 ? 'y' : 'ies'}`));
+      this.printConvergence(
+        distribution,
+        answerResult.data?.answer ?? '',
+        this.formatApiError(conclusionsResult.error),
+      );
+
+      context.lastResult = {
+        subject_id: subjectId,
+        event_count: events.length,
+        distribution,
+        answer: answerResult.data?.answer,
+        confidence: answerResult.data?.confidence,
+        conclusions,
+        event_ids: events.map(event => event.memory.id),
+      };
+    } catch (error) {
+      spinner.fail(chalk.red(`Converge failed: ${error instanceof Error && error.message ? error.message : String(error)}`));
+    } finally {
+      resumeReadline();
+    }
+  }
+
+  private eventTypesFor(memory: MemoryEntry): EventType[] {
+    const types = new Set<EventType>();
+    for (const tag of memory.tags ?? []) {
+      const type = eventTypeFromTag(tag);
+      if (type) types.add(type);
+    }
+    return Array.from(types);
+  }
+
+  private eventDistribution(events: ConvergedEvent[]): Record<EventType, number> {
+    const distribution = Object.fromEntries(EVENT_TYPES.map(type => [type, 0])) as Record<EventType, number>;
+    for (const event of events) {
+      for (const type of event.types) {
+        distribution[type] += 1;
+      }
+    }
+    return distribution;
+  }
+
+  private formatEventDigest(events: ConvergedEvent[]): string {
+    return events.map((event, index) => {
+      const createdAt = event.memory.created_at ? event.memory.created_at.slice(0, 10) : 'unknown-date';
+      const content = event.memory.content.replace(/\s+/g, ' ').slice(0, 360);
+      return [
+        `${index + 1}. id=${event.memory.id}`,
+        `   date=${createdAt}`,
+        `   types=${event.types.map(type => eventTag(type)).join(', ')}`,
+        `   title=${event.memory.title}`,
+        `   content=${content}`,
+      ].join('\n');
+    }).join('\n\n');
+  }
+
+  private buildConvergenceQuestion(input: {
+    subjectId: string;
+    events: ConvergedEvent[];
+    distribution: Record<EventType, number>;
+    conclusionDigest: string;
+  }): string {
+    const distributionLines = EVENT_TYPES
+      .map(type => `- ${type}: ${input.distribution[type]}`)
+      .join('\n');
+    const topRevisits = input.events
+      .filter(event => event.types.includes('revisit'))
+      .slice(0, 5)
+      .map(event => event.memory.id)
+      .join(', ') || 'none';
+
+    return `You are synthesizing across ${input.events.length} captured events for subject ${input.subjectId}.
+
+Event distribution:
+${distributionLines}
+- top revisit event IDs: ${topRevisits}
+
+Pre-reasoned conclusions:
+${input.conclusionDigest || '(none available)'}
+
+Captured events with provenance:
+${this.formatEventDigest(input.events)}
+
+Produce exactly three blocks:
+
+MIND: Structural patterns across decisions and insights. What is this user systematically building toward? Where are decisions diverging from stated commitments?
+
+HEART: Emotional and motivational patterns across frustrations, abandons, and revisits. What keeps pulling them back? What keeps draining them?
+
+CONCIERGE: 1-3 concrete next actions. Each action must cite at least one event ID as provenance and answer what the user's past self would thank their present self for doing now.`;
+  }
+
+  private printConvergence(
+    distribution: Record<EventType, number>,
+    answer: string,
+    conclusionsError?: string,
+  ): void {
+    console.log(chalk.cyan('\nEvent distribution:'));
+    for (const type of EVENT_TYPES) {
+      console.log(chalk.gray(`  ${type.padEnd(12)} ${distribution[type]}`));
+    }
+    if (conclusionsError) {
+      console.log(chalk.yellow(`\nConclusions unavailable: ${conclusionsError}`));
+    }
+    console.log(chalk.cyan('\nConvergence:\n'));
+    console.log(answer.trim() || chalk.gray('(empty answer)'));
+    console.log('');
+  }
+
+  private formatApiError(error: unknown): string | undefined {
+    if (!error) return undefined;
+    if (typeof error === 'string') return error;
+    if (error instanceof Error) return error.message;
+    if (typeof error === 'object') {
+      const maybe = error as { message?: unknown; error?: unknown };
+      if (typeof maybe.message === 'string') return maybe.message;
+      if (typeof maybe.error === 'string') return maybe.error;
+    }
+    return String(error);
   }
 
   // Phase 2: Living Memory Profile commands

--- a/packages/repl-cli/src/core/repl-engine.ts
+++ b/packages/repl-cli/src/core/repl-engine.ts
@@ -249,6 +249,16 @@ export class ReplEngine {
     // Capture-event ontology (tag, untag, detect, types)
     this.registry.register('event', (args, ctx) => this.eventCommands.run(args, ctx), ['ev']);
 
+    // Context convergence (Phase B): synthesize event:* memories via Mind/Heart/Concierge
+    this.registry.register('context', async (args, ctx) => {
+      const sub = args[0];
+      if (sub === 'converge') {
+        await this.memoryCommands.contextConverge(args.slice(1), ctx);
+      } else {
+        console.log(chalk.yellow('Usage: context converge --subject=<uuid> [--limit=200] [--include-backfilled]'));
+      }
+    }, ['ctx']);
+
     // System commands
     this.registry.register('mode', (args, ctx) => this.systemCommands.mode(args, ctx));
     this.registry.register('status', (args, ctx) => this.systemCommands.status(args, ctx));
@@ -753,6 +763,7 @@ export class ReplEngine {
     console.log(chalk.gray('    event tag <id> <type>   - Add event:<type> tag to a memory'));
     console.log(chalk.gray('    event untag <id> [type] - Remove event tag(s) from a memory'));
     console.log(chalk.gray('    create ... --event=<t>  - Save a memory pre-tagged with event:<t>'));
+    console.log(chalk.gray('    context converge --subject=<id> - Synthesize event:* memories'));
 
     console.log(chalk.white('\n  System Commands:'));
     console.log(chalk.gray('    nl [on|off]             - Toggle natural language mode'));

--- a/packages/repl-cli/tests/memory-commands.test.ts
+++ b/packages/repl-cli/tests/memory-commands.test.ts
@@ -7,6 +7,8 @@ vi.mock('ora', () => ({
     start: () => ({
       succeed: () => {},
       fail: () => {},
+      get text() { return ''; },
+      set text(_value: string) {},
     }),
   }),
 }));
@@ -93,6 +95,84 @@ describe('MemoryCommands', () => {
 
     expect(mockClient.updateMemory).toHaveBeenCalledWith(memoryId, {
       content: 'replace this content',
+    });
+  });
+
+  it('converges event-tagged memories through profile synthesis', async () => {
+    const memoriesByTag: Record<string, any[]> = {
+      'event:decision': [{
+        id: 'mem-decision',
+        title: 'Use event ontology',
+        content: 'We decided to use event tags as the convergence spine.',
+        memory_type: 'project',
+        status: 'active',
+        access_count: 0,
+        user_id: 'user-1',
+        tags: ['event:decision'],
+        created_at: '2026-05-24T10:00:00Z',
+        updated_at: '2026-05-24T10:00:00Z',
+      }],
+      'event:frustration': [{
+        id: 'mem-frustration',
+        title: 'Thin wrappers are not enough',
+        content: 'The implementation keeps collapsing into memory search.',
+        memory_type: 'project',
+        status: 'active',
+        access_count: 0,
+        user_id: 'user-1',
+        tags: ['event:frustration'],
+        created_at: '2026-05-24T11:00:00Z',
+        updated_at: '2026-05-24T11:00:00Z',
+      }],
+      'event:insight': [{
+        id: 'mem-insight',
+        title: 'Convergence needs provenance',
+        content: 'Insight connects event IDs to next actions.',
+        memory_type: 'knowledge',
+        status: 'active',
+        access_count: 0,
+        user_id: 'user-1',
+        tags: ['event:insight', 'backfilled:true'],
+        created_at: '2026-05-24T12:00:00Z',
+        updated_at: '2026-05-24T12:00:00Z',
+      }],
+    };
+    const mockClient = {
+      listMemories: vi.fn().mockImplementation(async (options: { tags?: string[] }) => ({
+        data: { data: memoriesByTag[options.tags?.[0] ?? ''] ?? [] },
+      })),
+      listInferredConclusions: vi.fn().mockResolvedValue({
+        data: { conclusions: [{ conclusion_type: 'pattern', confidence: 0.82, content: 'The user values substance over wrappers.' }] },
+      }),
+      askProfile: vi.fn().mockResolvedValue({
+        data: { answer: 'MIND: Build toward convergence.\nHEART: Thin wrappers drain trust.\nCONCIERGE: Cite mem-decision.', confidence: 0.9 },
+      }),
+    };
+
+    (commands as any).client = mockClient;
+    await commands.contextConverge(['--subject=subject-1', '--limit=20'], context);
+
+    expect(mockClient.listMemories).toHaveBeenCalledWith(expect.objectContaining({
+      tags: ['event:decision'],
+      status: 'active',
+      limit: 20,
+    }));
+    expect(mockClient.listInferredConclusions).toHaveBeenCalledWith({
+      subject_id: 'subject-1',
+      limit: 12,
+    });
+    expect(mockClient.askProfile).toHaveBeenCalledTimes(1);
+    expect(mockClient.askProfile.mock.calls[0][0]).toBe('subject-1');
+    expect(mockClient.askProfile.mock.calls[0][1]).toContain('mem-decision');
+    expect(mockClient.askProfile.mock.calls[0][1]).toContain('MIND: Structural patterns');
+    expect(context.lastResult).toMatchObject({
+      subject_id: 'subject-1',
+      event_count: 2,
+      distribution: {
+        decision: 1,
+        frustration: 1,
+        insight: 0,
+      },
     });
   });
 });

--- a/packages/repl-cli/tests/memory-commands.test.ts
+++ b/packages/repl-cli/tests/memory-commands.test.ts
@@ -136,6 +136,18 @@ describe('MemoryCommands', () => {
         created_at: '2026-05-24T12:00:00Z',
         updated_at: '2026-05-24T12:00:00Z',
       }],
+      'event:commitment': [{
+        id: 'mem-commitment',
+        title: 'Ship convergence v0 this sprint',
+        content: 'I will land the converge command before the next review.',
+        memory_type: 'project',
+        status: 'active',
+        access_count: 0,
+        user_id: 'user-1',
+        tags: ['event:commitment'],
+        created_at: '2026-05-24T13:00:00Z',
+        updated_at: '2026-05-24T13:00:00Z',
+      }],
     };
     const mockClient = {
       listMemories: vi.fn().mockImplementation(async (options: { tags?: string[] }) => ({
@@ -167,12 +179,113 @@ describe('MemoryCommands', () => {
     expect(mockClient.askProfile.mock.calls[0][1]).toContain('MIND: Structural patterns');
     expect(context.lastResult).toMatchObject({
       subject_id: 'subject-1',
-      event_count: 2,
+      event_count: 3,
       distribution: {
         decision: 1,
         frustration: 1,
+        commitment: 1,
         insight: 0,
       },
+    });
+  });
+
+  it('converge: short-circuits with low_signal=true when corpus has no event-tagged memories', async () => {
+    const mockClient = {
+      listMemories: vi.fn().mockResolvedValue({ data: { data: [] } }),
+      listInferredConclusions: vi.fn(),
+      askProfile: vi.fn(),
+    };
+    (commands as any).client = mockClient;
+
+    await commands.contextConverge(['--subject=subject-empty'], context);
+
+    expect(mockClient.askProfile).not.toHaveBeenCalled();
+    expect(mockClient.listInferredConclusions).not.toHaveBeenCalled();
+    expect(context.lastResult).toMatchObject({
+      events: [],
+      distribution: {},
+      low_signal: true,
+    });
+  });
+
+  it('converge: skips synthesis on a single event (below MIN_EVENTS_FOR_CONVERGENCE)', async () => {
+    const singleEvent = {
+      id: 'mem-only',
+      title: 'Solo commitment',
+      content: 'I will revisit this next session.',
+      memory_type: 'project',
+      status: 'active',
+      access_count: 0,
+      user_id: 'user-1',
+      tags: ['event:commitment'],
+      created_at: '2026-05-24T10:00:00Z',
+      updated_at: '2026-05-24T10:00:00Z',
+    };
+    const mockClient = {
+      listMemories: vi.fn().mockImplementation(async (opts: { tags?: string[] }) => ({
+        data: { data: opts.tags?.[0] === 'event:commitment' ? [singleEvent] : [] },
+      })),
+      listInferredConclusions: vi.fn(),
+      askProfile: vi.fn(),
+    };
+    (commands as any).client = mockClient;
+
+    await commands.contextConverge(['--subject=subject-low'], context);
+
+    // Critical: askProfile must NOT be called — the prompt template would
+    // fabricate Mind/Heart/Concierge blocks from a single event.
+    expect(mockClient.askProfile).not.toHaveBeenCalled();
+    expect(mockClient.listInferredConclusions).not.toHaveBeenCalled();
+    expect(context.lastResult).toMatchObject({
+      subject_id: 'subject-low',
+      event_count: 1,
+      low_signal: true,
+      event_ids: ['mem-only'],
+    });
+  });
+
+  it('converge: skips synthesis at exactly 2 events (boundary just below threshold)', async () => {
+    const memoriesByTag: Record<string, any[]> = {
+      'event:decision': [{
+        id: 'mem-d',
+        title: 'Decision one',
+        content: 'we decided to wait',
+        memory_type: 'project',
+        status: 'active',
+        access_count: 0,
+        user_id: 'user-1',
+        tags: ['event:decision'],
+        created_at: '2026-05-24T09:00:00Z',
+        updated_at: '2026-05-24T09:00:00Z',
+      }],
+      'event:frustration': [{
+        id: 'mem-f',
+        title: 'Frustration one',
+        content: 'this is annoying',
+        memory_type: 'project',
+        status: 'active',
+        access_count: 0,
+        user_id: 'user-1',
+        tags: ['event:frustration'],
+        created_at: '2026-05-24T10:00:00Z',
+        updated_at: '2026-05-24T10:00:00Z',
+      }],
+    };
+    const mockClient = {
+      listMemories: vi.fn().mockImplementation(async (opts: { tags?: string[] }) => ({
+        data: { data: memoriesByTag[opts.tags?.[0] ?? ''] ?? [] },
+      })),
+      listInferredConclusions: vi.fn(),
+      askProfile: vi.fn(),
+    };
+    (commands as any).client = mockClient;
+
+    await commands.contextConverge(['--subject=subject-2'], context);
+
+    expect(mockClient.askProfile).not.toHaveBeenCalled();
+    expect(context.lastResult).toMatchObject({
+      event_count: 2,
+      low_signal: true,
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds the first Layer B proof on top of the capture-event ontology implementation from PR #123.

- Adds `context converge --subject=<uuid> [--limit=200] [--include-backfilled]` to the REPL (`ctx` alias included)
- Reads exact `event:<type>` tags across all 7 canonical event types, dedupes memories, and excludes `backfilled:true` by default
- Composes existing MaaS intelligence surfaces: `listInferredConclusions()` for prior reasoning and `askProfile()` for Mind / Heart / Concierge synthesis
- Keeps convergence grounded with event IDs in the prompt and stores provenance in `context.lastResult`
- Adds unit coverage for event filtering, profile synthesis, and default backfill exclusion

## Relation to PR #123

Stacked on `feat/capture-event-ontology-impl` because this command depends on the event tag helpers and `event:*` conventions introduced there. After #123 merges, this PR can be retargeted to `main`.

## Test plan

- `bun run type-check`
- `bun run build`
- `bun run test` — 97 passed, 2 skipped
- `bunx tsx tests/smoke/events.mjs` — smoke pass
