### PR TITLE
fix(repl-cli): three post-merge converge follow-ups from review (subject scoping, payload tags, smoke pipeline)

### DIFF
--- a/packages/repl-cli/package.json
+++ b/packages/repl-cli/package.json
@@ -50,7 +50,9 @@
     "build": "tsup && chmod +x dist/index.js",
     "dev": "tsup --watch",
     "start": "node dist/index.js",
-    "test": "[ -d node_modules/chalk ] || bun install --no-save; vitest run",
+    "test": "[ -d node_modules/chalk ] || bun install --no-save; vitest run && bun run test:smoke",
+    "test:unit": "[ -d node_modules/chalk ] || bun install --no-save; vitest run",
+    "test:smoke": "bunx tsx tests/smoke/events.mjs && bunx tsx tests/smoke/persona.mjs",
     "type-check": "tsc --noEmit",
     "prepublishOnly": "npm run build"
   },

--- a/packages/repl-cli/src/commands/memory-commands.ts
+++ b/packages/repl-cli/src/commands/memory-commands.ts
@@ -565,6 +565,11 @@ export class MemoryCommands {
 
         for (const memory of result.data?.data ?? []) {
           if (!includeBackfilled && memory.tags?.includes(TAG_BACKFILLED)) continue;
+          // Cross-subject contamination guard: the SDK's listMemories has no
+          // subject_id filter today, so events from other users in the same
+          // org would otherwise leak into this subject's synthesis. Drop any
+          // memory whose user_id doesn't match the requested subject.
+          if (memory.user_id !== subjectId) continue;
           byId.set(memory.id, memory);
         }
       }

--- a/packages/repl-cli/src/events/tags.ts
+++ b/packages/repl-cli/src/events/tags.ts
@@ -77,8 +77,38 @@ export function stripAllEventTags(tags: string[]): string[] {
     && !t.startsWith('abandoned-from:'));
 }
 
-/** Strip only `event:<type>` (leave other event tags + payload tags). */
+/**
+ * Payload-tag prefixes associated with each event type. When an
+ * `event:<type>` tag is removed, the orphaned payload tags get removed
+ * too — leaving `due:friday` on a memory that's no longer marked
+ * `event:commitment` is semantic drift.
+ *
+ * Only event types with payload tags are listed; the rest have an
+ * empty array and the strip is a no-op for payload tags.
+ */
+const PAYLOAD_PREFIXES_BY_TYPE: Record<EventType, readonly string[]> = {
+  decision:    [],
+  commitment:  ['due:'],
+  frustration: ['tool:'],
+  surprise:    [],
+  insight:     [],
+  revisit:     ['revisit-of:'],
+  abandon:     ['abandoned-from:'],
+};
+
+/**
+ * Strip `event:<type>` and any payload tags that belong to that type.
+ * Leaves other `event:*` tags and unrelated tags untouched.
+ *
+ * Example: stripEventTypeTag(['event:commitment','due:friday','other'], 'commitment')
+ *   → ['other']   (event:commitment AND due:friday both removed)
+ */
 export function stripEventTypeTag(tags: string[], type: EventType): string[] {
   const target = eventTag(type);
-  return tags.filter(t => t !== target);
+  const payloadPrefixes = PAYLOAD_PREFIXES_BY_TYPE[type];
+  return tags.filter(t => {
+    if (t === target) return false;
+    for (const p of payloadPrefixes) if (t.startsWith(p)) return false;
+    return true;
+  });
 }

--- a/packages/repl-cli/tests/memory-commands.test.ts
+++ b/packages/repl-cli/tests/memory-commands.test.ts
@@ -107,7 +107,7 @@ describe('MemoryCommands', () => {
         memory_type: 'project',
         status: 'active',
         access_count: 0,
-        user_id: 'user-1',
+        user_id: 'subject-1',
         tags: ['event:decision'],
         created_at: '2026-05-24T10:00:00Z',
         updated_at: '2026-05-24T10:00:00Z',
@@ -119,7 +119,7 @@ describe('MemoryCommands', () => {
         memory_type: 'project',
         status: 'active',
         access_count: 0,
-        user_id: 'user-1',
+        user_id: 'subject-1',
         tags: ['event:frustration'],
         created_at: '2026-05-24T11:00:00Z',
         updated_at: '2026-05-24T11:00:00Z',
@@ -131,7 +131,7 @@ describe('MemoryCommands', () => {
         memory_type: 'knowledge',
         status: 'active',
         access_count: 0,
-        user_id: 'user-1',
+        user_id: 'subject-1',
         tags: ['event:insight', 'backfilled:true'],
         created_at: '2026-05-24T12:00:00Z',
         updated_at: '2026-05-24T12:00:00Z',
@@ -143,7 +143,7 @@ describe('MemoryCommands', () => {
         memory_type: 'project',
         status: 'active',
         access_count: 0,
-        user_id: 'user-1',
+        user_id: 'subject-1',
         tags: ['event:commitment'],
         created_at: '2026-05-24T13:00:00Z',
         updated_at: '2026-05-24T13:00:00Z',
@@ -216,7 +216,7 @@ describe('MemoryCommands', () => {
       memory_type: 'project',
       status: 'active',
       access_count: 0,
-      user_id: 'user-1',
+      user_id: 'subject-low',
       tags: ['event:commitment'],
       created_at: '2026-05-24T10:00:00Z',
       updated_at: '2026-05-24T10:00:00Z',
@@ -253,7 +253,7 @@ describe('MemoryCommands', () => {
         memory_type: 'project',
         status: 'active',
         access_count: 0,
-        user_id: 'user-1',
+        user_id: 'subject-2',
         tags: ['event:decision'],
         created_at: '2026-05-24T09:00:00Z',
         updated_at: '2026-05-24T09:00:00Z',
@@ -265,7 +265,7 @@ describe('MemoryCommands', () => {
         memory_type: 'project',
         status: 'active',
         access_count: 0,
-        user_id: 'user-1',
+        user_id: 'subject-2',
         tags: ['event:frustration'],
         created_at: '2026-05-24T10:00:00Z',
         updated_at: '2026-05-24T10:00:00Z',
@@ -287,5 +287,76 @@ describe('MemoryCommands', () => {
       event_count: 2,
       low_signal: true,
     });
+  });
+
+  it('converge: drops other-user memories before synthesis (cross-subject contamination guard)', async () => {
+    // Subject under test
+    const me = 'subject-target';
+    const intruder = 'subject-other-user';
+
+    // 4 event-tagged memories total: 3 belong to `me`, 1 belongs to another user.
+    // Without the user_id filter, the other user's `event:insight` would leak
+    // into `me`'s Mind/Heart/Concierge synthesis — that's the contamination
+    // this test guards against. With the filter, only 3 events reach synthesis.
+    const memoriesByTag: Record<string, any[]> = {
+      'event:decision': [{
+        id: 'mem-mine-d', user_id: me, tags: ['event:decision'],
+        title: 'My decision', content: 'we chose A over B for my project',
+        memory_type: 'project', status: 'active', access_count: 0,
+        created_at: '2026-05-24T09:00:00Z', updated_at: '2026-05-24T09:00:00Z',
+      }],
+      'event:commitment': [{
+        id: 'mem-mine-c', user_id: me, tags: ['event:commitment'],
+        title: 'My commitment', content: 'I will ship by Friday',
+        memory_type: 'project', status: 'active', access_count: 0,
+        created_at: '2026-05-24T10:00:00Z', updated_at: '2026-05-24T10:00:00Z',
+      }],
+      'event:insight': [
+        {
+          id: 'mem-mine-i', user_id: me, tags: ['event:insight'],
+          title: 'My insight', content: 'these two problems are the same',
+          memory_type: 'knowledge', status: 'active', access_count: 0,
+          created_at: '2026-05-24T11:00:00Z', updated_at: '2026-05-24T11:00:00Z',
+        },
+        {
+          id: 'mem-intruder-i', user_id: intruder, tags: ['event:insight'],
+          title: 'Someone elses insight', content: 'sensitive content from another user',
+          memory_type: 'knowledge', status: 'active', access_count: 0,
+          created_at: '2026-05-24T12:00:00Z', updated_at: '2026-05-24T12:00:00Z',
+        },
+      ],
+    };
+    const mockClient = {
+      listMemories: vi.fn().mockImplementation(async (opts: { tags?: string[] }) => ({
+        data: { data: memoriesByTag[opts.tags?.[0] ?? ''] ?? [] },
+      })),
+      listInferredConclusions: vi.fn().mockResolvedValue({ data: { conclusions: [] } }),
+      askProfile: vi.fn().mockResolvedValue({
+        data: { answer: 'MIND: ...\nHEART: ...\nCONCIERGE: ...', confidence: 0.8 },
+      }),
+    };
+    (commands as any).client = mockClient;
+
+    await commands.contextConverge([`--subject=${me}`], context);
+
+    // Synthesis fires (3 of mine ≥ MIN_EVENTS_FOR_CONVERGENCE)
+    expect(mockClient.askProfile).toHaveBeenCalledTimes(1);
+
+    // The prompt must include only the requesting subject's events
+    const prompt = mockClient.askProfile.mock.calls[0][1] as string;
+    expect(prompt).toContain('mem-mine-d');
+    expect(prompt).toContain('mem-mine-c');
+    expect(prompt).toContain('mem-mine-i');
+    expect(prompt).not.toContain('mem-intruder-i');
+    expect(prompt).not.toContain('sensitive content from another user');
+
+    expect(context.lastResult).toMatchObject({
+      subject_id: me,
+      event_count: 3,
+      event_ids: expect.arrayContaining(['mem-mine-d', 'mem-mine-c', 'mem-mine-i']),
+    });
+    // Defensive: the other user's id must not appear anywhere in event_ids
+    const ids = (context.lastResult as any).event_ids as string[];
+    expect(ids).not.toContain('mem-intruder-i');
   });
 });

--- a/packages/repl-cli/tests/smoke/events.mjs
+++ b/packages/repl-cli/tests/smoke/events.mjs
@@ -116,9 +116,37 @@ try {
   assert(!oneStripped.includes('event:decision'),
     'stripEventTypeTag removes event:decision');
   assert(oneStripped.includes('event:commitment') && oneStripped.includes('due:friday'),
-    'stripEventTypeTag leaves other event tags intact');
+    'stripEventTypeTag(decision) leaves event:commitment + due:friday intact (different type, different payload)');
   assert(oneStripped.includes('other-tag'),
     'stripEventTypeTag preserves non-event tags');
+
+  // Fix 3: stripping a type ALSO strips that type's own payload tags
+  // (otherwise removing event:commitment would orphan due:friday — semantic drift)
+  const commitmentStripped = stripEventTypeTag(tagsBefore, 'commitment');
+  assert(!commitmentStripped.includes('event:commitment'),
+    'stripEventTypeTag(commitment) removes event:commitment');
+  assert(!commitmentStripped.includes('due:friday'),
+    'stripEventTypeTag(commitment) ALSO removes orphaned due:* payload (no semantic drift)');
+  assert(commitmentStripped.includes('event:decision'),
+    'stripEventTypeTag(commitment) leaves unrelated event types alone');
+  assert(commitmentStripped.includes('other-tag'),
+    'stripEventTypeTag(commitment) preserves non-event tags');
+
+  // Spot-check the rest of the payload-prefix mapping
+  const revisitTags = ['event:revisit', 'revisit-of:abc-123', 'other-tag'];
+  const revisitStripped = stripEventTypeTag(revisitTags, 'revisit');
+  assert(!revisitStripped.includes('revisit-of:abc-123'),
+    'stripEventTypeTag(revisit) removes revisit-of:* payload');
+
+  const abandonTags = ['event:abandon', 'abandoned-from:xyz-789', 'other-tag'];
+  const abandonStripped = stripEventTypeTag(abandonTags, 'abandon');
+  assert(!abandonStripped.includes('abandoned-from:xyz-789'),
+    'stripEventTypeTag(abandon) removes abandoned-from:* payload');
+
+  const frustrationTags = ['event:frustration', 'tool:bun', 'other-tag'];
+  const frustrationStripped = stripEventTypeTag(frustrationTags, 'frustration');
+  assert(!frustrationStripped.includes('tool:bun'),
+    'stripEventTypeTag(frustration) removes tool:* payload');
 
   // ── 3. Type guards ───────────────────────────────────────────────────
   console.log('\n[3] Type guards');

--- a/packages/repl-cli/tests/smoke/persona.mjs
+++ b/packages/repl-cli/tests/smoke/persona.mjs
@@ -35,15 +35,13 @@ try {
   // ── 1. Registry exercises ───────────────────────────────────────────
   console.log('\n[1] PersonaRegistry');
   // Paths are relative to this file's location (tests/smoke/persona.mjs).
-  // The dist path is preferred for end-to-end coverage; the source-tree
-  // fallback lets the script run pre-build via tsx.
-  const { getPersonaRegistry, BUILTIN_PERSONAS } = await import('../../dist/index.js')
-    .catch(async () => {
-      return await import('../../src/personas/registry.ts').then(async (m) => ({
-        getPersonaRegistry: m.getPersonaRegistry,
-        BUILTIN_PERSONAS: (await import('../../src/personas/builtin.ts')).BUILTIN_PERSONAS,
-      }));
-    });
+  // We import from src/ directly — dist/index.js is the CLI entry and
+  // does NOT re-export persona helpers (would require a separate
+  // package surface), so destructuring from dist returns `undefined`
+  // for these symbols and fails the smoke. Always go to source via
+  // the tsx runtime (this script is run with `bunx tsx`).
+  const { getPersonaRegistry } = await import('../../src/personas/registry.ts');
+  const { BUILTIN_PERSONAS } = await import('../../src/personas/builtin.ts');
 
   const registry = getPersonaRegistry();
   const list = registry.list();


### PR DESCRIPTION
## Summary

Three correctness/hygiene fixes surfaced by review of the just-merged converge stack (PRs #118/#123/#124). Each commit is a discrete fix with its own test coverage.

| # | Severity | Fix |
|---|---|---|
| 1 | **Correctness (cross-user data leak)** | \`/context converge\` now filters memories by \`user_id === subjectId\` before synthesis |
| 2 | Data consistency | \`stripEventTypeTag\` cleans the stripped type's payload tags too (\`due:*\` with commitment, \`revisit-of:*\` with revisit, etc.) |
| 3 | Release-signal hygiene | Smoke tests wired into \`bun run test\` + \`persona.mjs\` fixed under both \`node\` and \`tsx\` |

## Finding 1 was the load-bearing one

The SDK's \`listMemories\` has no \`subject_id\` filter. \`contextConverge\` was gathering memories purely by \`event:*\` tag, then feeding them into a synthesis prompt scoped to the requested \`subjectId\`. Result: in any multi-user org, the Mind/Heart/Concierge synthesis could reason about user A using user B's event-tagged memories.

The CLI-side filter (\`memory.user_id !== subjectId → drop\`) closes the gap without requiring SDK or API changes. \`MemoryEntry.user_id\` already exists on every record (verified live).

A proper server-side fix (subject_id query param on \`GET /memories?tags=...\`) is the right long-term move and is noted in the commit message for a follow-up.

## Test plan

- [x] \`bun run type-check\` — clean
- [x] \`bun run test:unit\` — **101 passed, 2 skipped, 0 failed** (was 100/2/0; +1 cross-subject test)
- [x] \`bun run test:smoke\` — events.mjs PASS + persona.mjs PASS (persona.mjs was broken before this PR)
- [x] \`bun run test\` (newly chains unit + smoke) — full release signal end-to-end green

🤖 Generated with [Claude Code](https://claude.com/claude-code)