### PR TITLE
fix(cli): make memory search fallback explicit

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - @lanonasis/cli
 
+## Unreleased
+
+### 🐛 Bug Fixes
+
+- **Memory search fallback is now explicit and CI-safe**: `memory search` reports lexical fallback metadata in JSON output, supports `--no-fallback`, `--fail-on-fallback`, and `--ci`, and redacts backend error strings before printing them.
+
 ## [3.11.1] - 2026-07-16
 
 ### 🐛 Bug Fixes

--- a/cli/README.md
+++ b/cli/README.md
@@ -300,6 +300,9 @@ onasis memory create                      # Prompts for missing fields
 # Search memories
 onasis memory search "api integration"
 onasis memory search "meeting notes" --type context
+onasis memory search "gateway parity" --no-fallback --json
+onasis memory search "gateway parity" --ci
+onasis memory search "gateway parity" --fail-on-fallback
 
 # Memory operations
 onasis memory get <id>                    # Get specific memory

--- a/cli/dist/commands/memory.js
+++ b/cli/dist/commands/memory.js
@@ -278,6 +278,31 @@ const lexicalFallbackSearch = async (query, searchOptions) => {
         .sort((a, b) => b.similarity_score - a.similarity_score)
         .slice(0, searchOptions.limit);
 };
+const normalizeSearchFallbackMode = (options) => {
+    if (options.ci || options.fallback === false) {
+        return 'never';
+    }
+    const rawMode = (options.fallbackMode || 'auto').trim().toLowerCase();
+    if (rawMode === 'auto' || rawMode === 'lexical' || rawMode === 'never') {
+        return rawMode;
+    }
+    throw new Error('Invalid --fallback-mode. Expected one of: auto, lexical, never');
+};
+const sanitizeSearchError = (message) => {
+    return message
+        .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer <redacted>')
+        .replace(/\b(lano|lms)_[A-Za-z0-9._-]{8,}\b/g, '$1_<redacted>')
+        .replace(/\b(sk|pk)_(live|test)_[A-Za-z0-9._-]{8,}\b/g, '$1_$2_<redacted>')
+        .replace(/\b(api[_-]?key|authorization|token)(\s*[:=]\s*)[^\s,;]+/gi, '$1$2<redacted>');
+};
+const toSearchJsonResult = (memory) => ({
+    id: memory.id,
+    title: memory.title,
+    memory_type: memory.memory_type,
+    tags: Array.isArray(memory.tags) ? memory.tags : [],
+    similarity_score: memory.similarity_score,
+    content_preview: truncateText(memory.content, 160) || '',
+});
 const resolveCurrentUserId = async () => {
     const profile = await apiClient.getUserProfile();
     if (!profile?.id) {
@@ -769,14 +794,22 @@ export function memoryCommands(program) {
         .option('--threshold <threshold>', 'similarity threshold (0-1)', '0.55')
         .option('--type <types>', 'filter by memory types (comma-separated)')
         .option('--tags <tags>', 'filter by tags (comma-separated)')
+        .option('--fallback-mode <mode>', 'fallback mode when semantic search returns no results or fails (auto, lexical, never)', 'auto')
+        .option('--no-fallback', 'disable CLI lexical fallback when semantic search fails or returns no results')
+        .option('--fail-on-fallback', 'exit non-zero if CLI lexical fallback is used')
+        .option('--ci', 'CI mode: disable fallback, emit JSON, and fail on backend search errors')
+        .option('--json', 'emit machine-readable JSON output')
         .action(async (queryParts, options) => {
         try {
             const query = Array.isArray(queryParts) ? queryParts.join(' ').trim() : String(queryParts || '').trim();
             if (!query) {
                 console.error(chalk.red('✖ Search query is required'));
                 process.exit(1);
+                return;
             }
-            const spinner = ora(`Searching for "${query}"...`).start();
+            const startedAt = Date.now();
+            const fallbackMode = normalizeSearchFallbackMode(options);
+            const jsonOutput = Boolean(options.json || options.ci);
             const requestedThreshold = clampThreshold(parseFloat(options.threshold || '0.55'));
             const searchOptions = {
                 limit: parseInt(options.limit || '20'),
@@ -794,6 +827,8 @@ export function memoryCommands(program) {
             let thresholdUsed = requestedThreshold;
             let searchStrategy = 'semantic';
             let semanticSearchError = null;
+            let fallbackUsed = false;
+            const spinner = jsonOutput ? null : ora(`Searching for "${query}"...`).start();
             for (const threshold of thresholdPlan) {
                 try {
                     const attempt = await apiClient.searchMemories(query, {
@@ -832,31 +867,70 @@ export function memoryCommands(program) {
                     }
                 }
                 catch (error) {
-                    semanticSearchError = error instanceof Error ? error.message : 'Unknown semantic search error';
+                    semanticSearchError = sanitizeSearchError(error instanceof Error ? error.message : 'Unknown semantic search error');
                     break;
                 }
             }
-            if (results.length === 0) {
+            if (results.length === 0 && fallbackMode !== 'never') {
                 const lexicalResults = await lexicalFallbackSearch(query, searchOptions);
                 if (lexicalResults.length > 0) {
                     results = lexicalResults;
                     searchStrategy = 'cli_lexical_fallback';
+                    fallbackUsed = true;
                 }
             }
-            spinner.stop();
+            if (semanticSearchError && fallbackMode === 'never') {
+                searchStrategy = 'semantic_failed';
+            }
+            spinner?.stop();
+            const totalResults = typeof result?.total_results === 'number' ? result.total_results : results.length;
+            const searchTimeMs = typeof result?.search_time_ms === 'number' ? result.search_time_ms : Date.now() - startedAt;
+            const jsonPayload = {
+                query,
+                total_results: totalResults,
+                results: results.map(toSearchJsonResult),
+                search_strategy: searchStrategy,
+                fallback_used: fallbackUsed,
+                fallback_mode: fallbackMode,
+                semantic_error: semanticSearchError,
+                threshold_requested: requestedThreshold,
+                threshold_used: thresholdUsed,
+                threshold_plan: thresholdPlan,
+                search_time_ms: searchTimeMs,
+            };
             if (results.length === 0) {
-                console.log(chalk.yellow('No memories found matching your search'));
-                if (semanticSearchError) {
-                    console.log(chalk.gray(`Semantic search error: ${semanticSearchError}`));
+                if (jsonOutput) {
+                    console.log(JSON.stringify(jsonPayload, null, 2));
                 }
-                console.log(chalk.gray(`Tried thresholds: ${thresholdPlan.map((t) => t.toFixed(2)).join(', ')}`));
+                else {
+                    console.log(chalk.yellow('No memories found matching your search'));
+                    if (semanticSearchError) {
+                        const fallbackHint = fallbackMode === 'never'
+                            ? 'Lexical fallback is disabled for this run.'
+                            : 'Lexical fallback did not find local matches.';
+                        console.log(chalk.gray(`Semantic search error: ${semanticSearchError}`));
+                        console.log(chalk.gray(fallbackHint));
+                    }
+                    console.log(chalk.gray(`Tried thresholds: ${thresholdPlan.map((t) => t.toFixed(2)).join(', ')}`));
+                }
+                if (semanticSearchError && fallbackMode === 'never') {
+                    process.exit(1);
+                }
                 return;
             }
-            if (semanticSearchError && searchStrategy === 'cli_lexical_fallback') {
+            if (jsonOutput) {
+                console.log(JSON.stringify(jsonPayload, null, 2));
+                if ((options.failOnFallback || options.ci) && fallbackUsed) {
+                    process.exit(1);
+                }
+                return;
+            }
+            if (semanticSearchError && fallbackUsed) {
                 console.log(chalk.yellow(`⚠ Semantic search unavailable, using lexical fallback (${semanticSearchError})`));
             }
-            const totalResults = typeof result?.total_results === 'number' ? result.total_results : results.length;
-            const searchTimeMs = typeof result?.search_time_ms === 'number' ? result.search_time_ms : 0;
+            else if (fallbackUsed) {
+                console.log(chalk.yellow('⚠ Semantic search returned no matches; using CLI lexical fallback'));
+            }
             console.log(chalk.blue.bold(`\n🔍 Search Results (${totalResults} found)`));
             console.log(chalk.gray(`Query: "${query}" | Search time: ${searchTimeMs}ms`));
             if (Math.abs(thresholdUsed - requestedThreshold) > 0.0001) {
@@ -882,9 +956,12 @@ export function memoryCommands(program) {
                 }
                 console.log();
             });
+            if ((options.failOnFallback || options.ci) && fallbackUsed) {
+                process.exit(1);
+            }
         }
         catch (error) {
-            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            const errorMessage = sanitizeSearchError(error instanceof Error ? error.message : 'Unknown error');
             console.error(chalk.red('✖ Search failed:'), errorMessage);
             process.exit(1);
         }

--- a/cli/src/__tests__/memory-search-fallback.test.ts
+++ b/cli/src/__tests__/memory-search-fallback.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { Command } from 'commander';
+
+const mockSearchMemories = jest.fn();
+const mockGetMemories = jest.fn();
+
+jest.unstable_mockModule('../utils/api.js', () => ({
+  apiClient: {
+    searchMemories: mockSearchMemories,
+    getMemories: mockGetMemories,
+  },
+}));
+
+jest.unstable_mockModule('chalk', () => ({
+  default: {
+    blue: { bold: (str: string) => str },
+    cyan: (str: string) => str,
+    gray: (str: string) => str,
+    green: (str: string) => str,
+    red: (str: string) => str,
+    yellow: (str: string) => str,
+    white: (str: string) => str,
+  },
+}));
+
+const memoryFixture = {
+  id: '11111111-1111-4111-8111-111111111111',
+  title: 'Gateway migration note',
+  content: 'Gateway routing should stay aligned across MCP and REST transports.',
+  memory_type: 'context',
+  tags: ['gateway'],
+  user_id: 'user-1',
+  organization_id: 'org-1',
+  created_at: '2026-07-18T00:00:00.000Z',
+  updated_at: '2026-07-18T00:00:00.000Z',
+  access_count: 0,
+};
+
+const parseJsonOutput = (consoleLogSpy: jest.SpyInstance) => {
+  const output = consoleLogSpy.mock.calls.map((call) => String(call[0])).join('\n');
+  return JSON.parse(output);
+};
+
+describe('memory search fallback contract', () => {
+  let consoleLogSpy: jest.SpyInstance;
+  let consoleErrorSpy: jest.SpyInstance;
+  let mockExit: jest.Mock;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockExit = process.exit as unknown as jest.Mock;
+    mockExit.mockClear();
+    mockSearchMemories.mockReset();
+    mockGetMemories.mockReset();
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  async function runSearchCmd(args: string[]) {
+    const { memoryCommands } = await import('../commands/memory.js');
+    const program = new Command();
+    program.exitOverride();
+    memoryCommands(program);
+    await program.parseAsync(['node', 'test', 'search', ...args], { from: 'node' });
+  }
+
+  it('uses lexical fallback by default and reports fallback metadata in JSON', async () => {
+    mockSearchMemories.mockRejectedValueOnce(new Error('503 backend unavailable Bearer secret-token'));
+    mockGetMemories.mockResolvedValueOnce({ memories: [memoryFixture] });
+
+    await runSearchCmd(['gateway', '--json']);
+
+    const payload = parseJsonOutput(consoleLogSpy);
+    expect(payload.search_strategy).toBe('cli_lexical_fallback');
+    expect(payload.fallback_used).toBe(true);
+    expect(payload.fallback_mode).toBe('auto');
+    expect(payload.semantic_error).toContain('Bearer <redacted>');
+    expect(payload.results).toHaveLength(1);
+    expect(payload.results[0]).toEqual(expect.objectContaining({
+      id: memoryFixture.id,
+      title: memoryFixture.title,
+      content_preview: expect.any(String),
+    }));
+    expect(mockGetMemories).toHaveBeenCalled();
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it('--fail-on-fallback emits results but exits non-zero when fallback is used', async () => {
+    mockSearchMemories.mockRejectedValueOnce(new Error('503 backend unavailable'));
+    mockGetMemories.mockResolvedValueOnce({ memories: [memoryFixture] });
+
+    await runSearchCmd(['gateway', '--json', '--fail-on-fallback']);
+
+    const payload = parseJsonOutput(consoleLogSpy);
+    expect(payload.fallback_used).toBe(true);
+    expect(payload.results).toHaveLength(1);
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it('--no-fallback fails loudly on semantic backend errors without client-side fallback', async () => {
+    mockSearchMemories.mockRejectedValueOnce(new Error('503 backend unavailable token=secret-token'));
+
+    await runSearchCmd(['gateway', '--json', '--no-fallback']);
+
+    const payload = parseJsonOutput(consoleLogSpy);
+    expect(payload.search_strategy).toBe('semantic_failed');
+    expect(payload.fallback_used).toBe(false);
+    expect(payload.fallback_mode).toBe('never');
+    expect(payload.semantic_error).toContain('token=<redacted>');
+    expect(payload.results).toHaveLength(0);
+    expect(mockGetMemories).not.toHaveBeenCalled();
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it('--ci is a JSON no-fallback mode for parity checks', async () => {
+    mockSearchMemories.mockRejectedValueOnce(new Error('503 backend unavailable lano_secretvalue'));
+
+    await runSearchCmd(['gateway', '--ci']);
+
+    const payload = parseJsonOutput(consoleLogSpy);
+    expect(payload.search_strategy).toBe('semantic_failed');
+    expect(payload.fallback_used).toBe(false);
+    expect(payload.fallback_mode).toBe('never');
+    expect(payload.semantic_error).toContain('lano_<redacted>');
+    expect(mockGetMemories).not.toHaveBeenCalled();
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});

--- a/cli/src/commands/memory.ts
+++ b/cli/src/commands/memory.ts
@@ -60,6 +60,11 @@ interface SearchMemoryOptions {
   threshold?: string;
   type?: string;
   tags?: string;
+  fallback?: boolean;
+  fallbackMode?: string;
+  failOnFallback?: boolean;
+  ci?: boolean;
+  json?: boolean;
 }
 
 interface UpdateMemoryOptions {
@@ -91,6 +96,8 @@ interface SearchParams {
   memory_types?: MemoryType[];
   tags?: string[];
 }
+
+type SearchFallbackMode = 'auto' | 'lexical' | 'never';
 
 interface GetMemoriesParams extends ApiGetMemoriesParams {
   page: number;
@@ -515,6 +522,36 @@ const lexicalFallbackSearch = async (
     .sort((a, b) => b.similarity_score - a.similarity_score)
     .slice(0, searchOptions.limit);
 };
+
+const normalizeSearchFallbackMode = (options: SearchMemoryOptions): SearchFallbackMode => {
+  if (options.ci || options.fallback === false) {
+    return 'never';
+  }
+
+  const rawMode = (options.fallbackMode || 'auto').trim().toLowerCase();
+  if (rawMode === 'auto' || rawMode === 'lexical' || rawMode === 'never') {
+    return rawMode;
+  }
+
+  throw new Error('Invalid --fallback-mode. Expected one of: auto, lexical, never');
+};
+
+const sanitizeSearchError = (message: string): string => {
+  return message
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer <redacted>')
+    .replace(/\b(lano|lms)_[A-Za-z0-9._-]{8,}\b/g, '$1_<redacted>')
+    .replace(/\b(sk|pk)_(live|test)_[A-Za-z0-9._-]{8,}\b/g, '$1_$2_<redacted>')
+    .replace(/\b(api[_-]?key|authorization|token)(\s*[:=]\s*)[^\s,;]+/gi, '$1$2<redacted>');
+};
+
+const toSearchJsonResult = (memory: MemorySearchResult) => ({
+  id: memory.id,
+  title: memory.title,
+  memory_type: memory.memory_type,
+  tags: Array.isArray(memory.tags) ? memory.tags : [],
+  similarity_score: memory.similarity_score,
+  content_preview: truncateText(memory.content, 160) || '',
+});
 
 const resolveCurrentUserId = async (): Promise<string> => {
   const profile = await apiClient.getUserProfile();
@@ -1066,16 +1103,23 @@ export function memoryCommands(program: Command): void {
     .option('--threshold <threshold>', 'similarity threshold (0-1)', '0.55')
     .option('--type <types>', 'filter by memory types (comma-separated)')
     .option('--tags <tags>', 'filter by tags (comma-separated)')
+    .option('--fallback-mode <mode>', 'fallback mode when semantic search returns no results or fails (auto, lexical, never)', 'auto')
+    .option('--no-fallback', 'disable CLI lexical fallback when semantic search fails or returns no results')
+    .option('--fail-on-fallback', 'exit non-zero if CLI lexical fallback is used')
+    .option('--ci', 'CI mode: disable fallback, emit JSON, and fail on backend search errors')
+    .option('--json', 'emit machine-readable JSON output')
     .action(async (queryParts: string[], options: SearchMemoryOptions) => {
       try {
         const query = Array.isArray(queryParts) ? queryParts.join(' ').trim() : String(queryParts || '').trim();
         if (!query) {
           console.error(chalk.red('✖ Search query is required'));
           process.exit(1);
+          return;
         }
 
-        const spinner = ora(`Searching for "${query}"...`).start();
-
+        const startedAt = Date.now();
+        const fallbackMode = normalizeSearchFallbackMode(options);
+        const jsonOutput = Boolean(options.json || options.ci);
         const requestedThreshold = clampThreshold(parseFloat(options.threshold || '0.55'));
         const searchOptions: SearchParams = {
           limit: parseInt(options.limit || '20'),
@@ -1100,6 +1144,9 @@ export function memoryCommands(program: Command): void {
         let thresholdUsed = requestedThreshold;
         let searchStrategy = 'semantic';
         let semanticSearchError: string | null = null;
+        let fallbackUsed = false;
+
+        const spinner = jsonOutput ? null : ora(`Searching for "${query}"...`).start();
 
         for (const threshold of thresholdPlan) {
           try {
@@ -1139,36 +1186,78 @@ export function memoryCommands(program: Command): void {
               break;
             }
           } catch (error: unknown) {
-            semanticSearchError = error instanceof Error ? error.message : 'Unknown semantic search error';
+            semanticSearchError = sanitizeSearchError(
+              error instanceof Error ? error.message : 'Unknown semantic search error'
+            );
             break;
           }
         }
 
-        if (results.length === 0) {
+        if (results.length === 0 && fallbackMode !== 'never') {
           const lexicalResults = await lexicalFallbackSearch(query, searchOptions);
           if (lexicalResults.length > 0) {
             results = lexicalResults;
             searchStrategy = 'cli_lexical_fallback';
+            fallbackUsed = true;
           }
         }
 
-        spinner.stop();
+        if (semanticSearchError && fallbackMode === 'never') {
+          searchStrategy = 'semantic_failed';
+        }
+
+        spinner?.stop();
+
+        const totalResults = typeof result?.total_results === 'number' ? result.total_results : results.length;
+        const searchTimeMs = typeof result?.search_time_ms === 'number' ? result.search_time_ms : Date.now() - startedAt;
+
+        const jsonPayload = {
+          query,
+          total_results: totalResults,
+          results: results.map(toSearchJsonResult),
+          search_strategy: searchStrategy,
+          fallback_used: fallbackUsed,
+          fallback_mode: fallbackMode,
+          semantic_error: semanticSearchError,
+          threshold_requested: requestedThreshold,
+          threshold_used: thresholdUsed,
+          threshold_plan: thresholdPlan,
+          search_time_ms: searchTimeMs,
+        };
 
         if (results.length === 0) {
-          console.log(chalk.yellow('No memories found matching your search'));
-          if (semanticSearchError) {
-            console.log(chalk.gray(`Semantic search error: ${semanticSearchError}`));
+          if (jsonOutput) {
+            console.log(JSON.stringify(jsonPayload, null, 2));
+          } else {
+            console.log(chalk.yellow('No memories found matching your search'));
+            if (semanticSearchError) {
+              const fallbackHint = fallbackMode === 'never'
+                ? 'Lexical fallback is disabled for this run.'
+                : 'Lexical fallback did not find local matches.';
+              console.log(chalk.gray(`Semantic search error: ${semanticSearchError}`));
+              console.log(chalk.gray(fallbackHint));
+            }
+            console.log(chalk.gray(`Tried thresholds: ${thresholdPlan.map((t) => t.toFixed(2)).join(', ')}`));
           }
-          console.log(chalk.gray(`Tried thresholds: ${thresholdPlan.map((t) => t.toFixed(2)).join(', ')}`));
+          if (semanticSearchError && fallbackMode === 'never') {
+            process.exit(1);
+          }
           return;
         }
 
-        if (semanticSearchError && searchStrategy === 'cli_lexical_fallback') {
-          console.log(chalk.yellow(`⚠ Semantic search unavailable, using lexical fallback (${semanticSearchError})`));
+        if (jsonOutput) {
+          console.log(JSON.stringify(jsonPayload, null, 2));
+          if ((options.failOnFallback || options.ci) && fallbackUsed) {
+            process.exit(1);
+          }
+          return;
         }
 
-        const totalResults = typeof result?.total_results === 'number' ? result.total_results : results.length;
-        const searchTimeMs = typeof result?.search_time_ms === 'number' ? result.search_time_ms : 0;
+        if (semanticSearchError && fallbackUsed) {
+          console.log(chalk.yellow(`⚠ Semantic search unavailable, using lexical fallback (${semanticSearchError})`));
+        } else if (fallbackUsed) {
+          console.log(chalk.yellow('⚠ Semantic search returned no matches; using CLI lexical fallback'));
+        }
 
         console.log(chalk.blue.bold(`\n🔍 Search Results (${totalResults} found)`));
         console.log(chalk.gray(`Query: "${query}" | Search time: ${searchTimeMs}ms`));
@@ -1201,8 +1290,12 @@ export function memoryCommands(program: Command): void {
           }
           console.log();
         });
+
+        if ((options.failOnFallback || options.ci) && fallbackUsed) {
+          process.exit(1);
+        }
       } catch (error: unknown) {
-        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        const errorMessage = sanitizeSearchError(error instanceof Error ? error.message : 'Unknown error');
         console.error(chalk.red('✖ Search failed:'), errorMessage);
         process.exit(1);
       }


### PR DESCRIPTION
## Summary

- Adds explicit fallback controls to `lanonasis memory search`: `--no-fallback`, `--fallback-mode`, `--fail-on-fallback`, `--ci`, and `--json`.
- Makes client-side lexical fallback visible through warnings and JSON metadata (`fallback_used`, `fallback_mode`, `search_strategy`, sanitized `semantic_error`).
- Keeps local default behavior friendly while giving CI/parity checks a loud failure path when semantic search fails or fallback is used.
- Adds focused Jest coverage for fallback default behavior, CI/no-fallback behavior, fail-on-fallback, and redacted backend errors.
- Updates package README/changelog and regenerated the tracked CLI dist file.

## Validation

- PASS: `npm test -- src/__tests__/memory-search-fallback.test.ts --runInBand`
- PASS: `npm run build`
- PASS: `node dist/index.js memory search --help`
- PASS: `npm pack --dry-run`
- PASS: `npm pack && tar -tf lanonasis-cli-3.11.1.tgz | rg 'node_modules/@lanonasis/secret-prescan|dist/commands/memory.js|package/package.json'`

## Known Existing Test Debt Observed

Full CLI suite was run with `npm test -- --runInBand`; it is still red on unrelated existing failures:

- `test/integration.test.ts`: `completion bash` and `config reset` timed out.
- `test/load.test.ts`: load/timing/auth expectation failures.
- `src/__tests__/api-client-auth-header.test.ts`: expected Supabase baseURL differs from current env-derived value.

These failures are outside the memory-search fallback diff and should remain separate follow-up work.
EOF'