### PR TITLE
fix: normalize Express route parameters

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
         "@types/bcryptjs": "^2.4.6",
         "@types/compression": "^1.7.5",
         "@types/cors": "^2.8.17",
-        "@types/express": "^5.0.0",
+        "@types/express": "^5.0.6",
         "@types/jest": "^29.5.14",
         "@types/jsonwebtoken": "^9.0.7",
         "@types/node": "^22.10.2",
@@ -638,7 +638,7 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/express": ["@types/express@5.0.3", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "*" } }, "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw=="],
+    "@types/express": ["@types/express@5.0.6", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "^2" } }, "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA=="],
 
     "@types/express-serve-static-core": ["@types/express-serve-static-core@5.0.7", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ=="],
 
@@ -692,7 +692,7 @@
 
     "@types/send": ["@types/send@0.17.5", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w=="],
 
-    "@types/serve-static": ["@types/serve-static@1.15.8", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "*" } }, "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg=="],
+    "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
 
     "@types/shimmer": ["@types/shimmer@1.2.0", "", {}, "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="],
 
@@ -2152,11 +2152,17 @@
 
     "@opentelemetry/sql-common/@opentelemetry/core": ["@opentelemetry/core@1.30.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ=="],
 
+    "@types/compression/@types/express": ["@types/express@5.0.3", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "*" } }, "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw=="],
+
     "@types/node-fetch/form-data": ["form-data@4.0.4", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow=="],
 
     "@types/request/form-data": ["form-data@2.5.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.35", "safe-buffer": "^5.2.1" } }, "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A=="],
 
     "@types/superagent/form-data": ["form-data@4.0.4", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow=="],
+
+    "@types/swagger-ui-express/@types/express": ["@types/express@5.0.3", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "*" } }, "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw=="],
+
+    "@types/swagger-ui-express/@types/serve-static": ["@types/serve-static@1.15.8", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "*" } }, "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
@@ -2454,6 +2460,8 @@
 
     "@opentelemetry/sql-common/@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
 
+    "@types/compression/@types/express/@types/serve-static": ["@types/serve-static@1.15.8", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "*" } }, "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg=="],
+
     "@types/node-fetch/form-data/hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "@types/node-fetch/form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
@@ -2557,6 +2565,8 @@
     "jest/@jest/types/@jest/schemas": ["@jest/schemas@29.6.3", "", { "dependencies": { "@sinclair/typebox": "^0.27.8" } }, "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA=="],
 
     "jwks-rsa/@types/express/@types/express-serve-static-core": ["@types/express-serve-static-core@4.19.7", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-FvPtiIf1LfhzsaIXhv/PHan/2FeQBbtBDtfX2QfvPxdUelMDEckK08SM6nqo1MIZY3RUlfA+HV8+hFUSio78qg=="],
+
+    "jwks-rsa/@types/express/@types/serve-static": ["@types/serve-static@1.15.8", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "*" } }, "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg=="],
 
     "openai/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@types/bcryptjs": "^2.4.6",
     "@types/compression": "^1.7.5",
     "@types/cors": "^2.8.17",
-    "@types/express": "^5.0.0",
+    "@types/express": "^5.0.6",
     "@types/jest": "^29.5.14",
     "@types/jsonwebtoken": "^9.0.7",
     "@types/node": "^22.10.2",

--- a/src/routes/api-keys.ts
+++ b/src/routes/api-keys.ts
@@ -4,6 +4,7 @@ import { alignedAuthMiddleware } from '@/middleware/auth-aligned';
 import { apiKeyService } from '@/services/apiKeyService';
 import type { ApiKey } from '@/services/apiKeyService';
 import { logger } from '@/utils/logger';
+import { getScalarRouteParam } from '@/utils/request';
 
 const router: express.Router = express.Router();
 
@@ -501,7 +502,7 @@ router.get('/:keyId', [
       return;
     }
 
-    const keyId = req.params.keyId;
+    const keyId = getScalarRouteParam(req.params.keyId);
     if (!keyId) {
       res.status(400).json({ error: 'Key ID is required' });
       return;
@@ -604,7 +605,7 @@ router.put('/:keyId', [
       return;
     }
 
-    const keyId = req.params.keyId;
+    const keyId = getScalarRouteParam(req.params.keyId);
     if (!keyId) {
       res.status(400).json({ error: 'Key ID is required' });
       return;
@@ -663,7 +664,7 @@ router.delete('/:keyId', [
       return;
     }
 
-    const keyId = req.params.keyId;
+    const keyId = getScalarRouteParam(req.params.keyId);
     if (!keyId) {
       res.status(400).json({ error: 'Key ID is required' });
       return;
@@ -1006,7 +1007,7 @@ router.post('/mcp/sessions/:sessionId/proxy-token', [
       return;
     }
 
-    const sessionId = req.params.sessionId;
+    const sessionId = getScalarRouteParam(req.params.sessionId);
     if (!sessionId) {
       res.status(400).json({ error: 'Session ID is required' });
       return;

--- a/src/routes/intelligence.ts
+++ b/src/routes/intelligence.ts
@@ -12,6 +12,7 @@ import {
   canReadIntelligenceSubject,
   resolveIntelligenceSubjectBoundary,
 } from '@/services/intelligenceAccess';
+import { getScalarRouteParam } from '@/utils/request';
 
 const router: Router = Router();
 const intelligenceService = new IntelligenceService();
@@ -90,7 +91,7 @@ router.get(
   alignedAuthMiddleware,
   planBasedRateLimit(),
   asyncHandler(async (req: Request, res: Response) => {
-    const { id } = req.params;
+    const id = getScalarRouteParam(req.params.id);
     if (!id) {
       res.status(400).json({ error: 'job id is required' });
       return;

--- a/src/routes/mcp-api-keys.ts
+++ b/src/routes/mcp-api-keys.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { param, body, validationResult } from 'express-validator';
 import { apiKeyService } from '../services/apiKeyService.js';
 import { logger } from '../utils/logger.js';
+import { getScalarRouteParam } from '../utils/request.js';
 
 const router: express.Router = express.Router();
 
@@ -205,8 +206,8 @@ router.post('/sessions/:sessionId/keys/:keyName/proxy-token', [
   param('keyName').isLength({ min: 1 }).withMessage('Key name is required')
 ], validateRequest, async (req: express.Request, res: express.Response) => {
   try {
-    const sessionId = req.params.sessionId;
-    const keyName = req.params.keyName;
+    const sessionId = getScalarRouteParam(req.params.sessionId);
+    const keyName = getScalarRouteParam(req.params.keyName);
     
     if (!sessionId || !keyName) {
       res.status(400).json({ error: 'Session ID and key name are required' });
@@ -284,7 +285,7 @@ router.post('/proxy-tokens/:proxyToken/resolve', [
   param('proxyToken').isLength({ min: 1 }).withMessage('Proxy token is required')
 ], validateRequest, async (req: express.Request, res: express.Response) => {
   try {
-    const proxyToken = req.params.proxyToken;
+    const proxyToken = getScalarRouteParam(req.params.proxyToken);
     
     if (!proxyToken) {
       res.status(400).json({ error: 'Proxy token is required' });
@@ -374,7 +375,7 @@ router.get('/sessions/:sessionId/status', [
   param('sessionId').isLength({ min: 1 }).withMessage('Session ID is required')
 ], validateRequest, async (req: express.Request, res: express.Response) => {
   try {
-    const sessionId = req.params.sessionId;
+    const sessionId = getScalarRouteParam(req.params.sessionId);
     
     if (!sessionId) {
       res.status(400).json({ error: 'Session ID is required' });
@@ -437,7 +438,7 @@ router.post('/sessions/:sessionId/end', [
   param('sessionId').isLength({ min: 1 }).withMessage('Session ID is required')
 ], validateRequest, async (req: express.Request, res: express.Response) => {
   try {
-    const sessionId = req.params.sessionId;
+    const sessionId = getScalarRouteParam(req.params.sessionId);
     
     if (!sessionId) {
       res.status(400).json({ error: 'Session ID is required' });

--- a/src/routes/memory.ts
+++ b/src/routes/memory.ts
@@ -27,6 +27,7 @@ interface SearchMemoryFilters {
   user_id?: string;
 }
 import { logMemoryOperation, logger } from '@/utils/logger';
+import { getScalarRouteParam } from '@/utils/request';
 
 const router: Router = Router();
 const memoryService = new MemoryService();
@@ -389,7 +390,7 @@ router.post('/search', asyncHandler(async (req: Request, res: Response) => {
  *         description: Memory not found
  */
 router.get('/:id', asyncHandler(async (req: Request, res: Response) => {
-  const { id } = req.params;
+  const id = getScalarRouteParam(req.params.id);
   if (!id) {
     res.status(400).json({
       error: 'Invalid memory ID',
@@ -474,7 +475,7 @@ router.get('/:id', asyncHandler(async (req: Request, res: Response) => {
  *         description: Access denied
  */
 router.put('/:id', asyncHandler(async (req: Request, res: Response) => {
-  const { id } = req.params;
+  const id = getScalarRouteParam(req.params.id);
   if (!id) {
     res.status(400).json({
       error: 'Invalid memory ID',
@@ -549,7 +550,7 @@ router.put('/:id', asyncHandler(async (req: Request, res: Response) => {
  *         description: Access denied
  */
 router.delete('/:id', asyncHandler(async (req: Request, res: Response) => {
-  const { id } = req.params;
+  const id = getScalarRouteParam(req.params.id);
   if (!id) {
     res.status(400).json({
       error: 'Invalid memory ID',

--- a/src/utils/__tests__/request.test.ts
+++ b/src/utils/__tests__/request.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { getScalarRouteParam } from '../request';
+
+describe('getScalarRouteParam', () => {
+  it('returns scalar string parameters', () => {
+    expect(getScalarRouteParam('memory-id')).toBe('memory-id');
+  });
+
+  it.each([undefined, null, ['memory-id'], 42])(
+    'rejects non-scalar route parameters: %j',
+    (value) => {
+      expect(getScalarRouteParam(value)).toBeUndefined();
+    },
+  );
+});

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,0 +1,2 @@
+export const getScalarRouteParam = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined;


### PR DESCRIPTION
## Summary
- normalize scalar route parameters at the HTTP boundary
- reject array-valued params instead of passing ambiguous values into services
- update Express types and lockfile to exercise current Express 5 declarations

## Why
Root monorepo Quality Gates resolve `@types/express-serve-static-core` 5.1.x, where route params may be `string | string[]`. The owning-repo lock previously resolved 5.0.x and masked this portability failure.

## Validation
- `bun install --frozen-lockfile`
- `bun run build`
- `bun run lint`
- `bun run test` (12 files, 149 tests)
- compiled successfully while `@types/express-serve-static-core` 5.1.2 was installed
- `git diff --check`

Follow-up to #135 and root thefixer3x/lan-onasis-monorepo#202.