### PR TITLE
fix(auth): infer OAuth request contract

### DIFF
--- a/src/middleware/centralAuth.ts
+++ b/src/middleware/centralAuth.ts
@@ -5,7 +5,6 @@ import {
   getSSOUserFromRequest,
   getSessionTokenFromRequest,
   hasSSOfromRequest,
-  type ServerRequest,
 } from '@lanonasis/oauth-client/server';
 
 // Use centralized type definitions
@@ -29,6 +28,8 @@ interface ApiKeyValidationResult {
   project_scope?: string;
 }
 
+type OAuthServerRequest = Parameters<typeof hasSSOfromRequest>[0];
+
 /**
  * Create authentication error with consistent format
  */
@@ -39,7 +40,7 @@ const createAuthError = (message: string, code: string, status = 401): AuthError
   return error;
 };
 
-const toOAuthServerRequest = (req: Request): ServerRequest => {
+const toOAuthServerRequest = (req: Request): OAuthServerRequest => {
   const cookieHeader = req.headers.cookie;
   const parsedCookies = (req as Request & { cookies?: Record<string, string> }).cookies;
 


### PR DESCRIPTION
## Summary
- infer the OAuth server request contract from the stable `hasSSOfromRequest` function
- avoid coupling MaaS to a named type export that is absent from one root workspace mirror
- preserve the exact structural adapter and runtime behavior

## Validation
- `bun install --frozen-lockfile`
- `bun run build`
- `bun run lint`
- `bun run test` (12 files, 149 tests)
- `git diff --check`

Follow-up to #135 and root thefixer3x/lan-onasis-monorepo#202.