### PR TITLE
fix(cli): keep memory ops on MCP host under --no-mcp

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,4 +1,4 @@
-# @lanonasis/cli v3.11.0 - Advanced CLI Suite
+# @lanonasis/cli v3.11.2 - Advanced CLI Suite
 
 [![NPM Version](https://img.shields.io/npm/v/@lanonasis/cli)](https://www.npmjs.com/package/@lanonasis/cli)
 [![Downloads](https://img.shields.io/npm/dt/@lanonasis/cli)](https://www.npmjs.com/package/@lanonasis/cli)
@@ -33,6 +33,83 @@ onasis health                                   # Verify system health
 # Create your first memory
 onasis memory create --title "Welcome" --content "My first memory"
 ```
+
+## 📖 Usage Guide (command reference)
+
+This section is the agent-facing usage guide for `@lanonasis/cli`. The command tree below is derived from `src/index.ts` and the `src/commands/*` modules (source of truth). Regenerate the live surface anytime with `lanonasis -h` / `lanonasis <command> -h` from a built checkout.
+
+### Binaries & aliases
+
+| Binary | Notes |
+|---|---|
+| `lanonasis` | canonical bin (`dist/index.js`) |
+| `onasis` | package.json bin alias |
+| `lanonasis-mcp` | MCP server entry (`dist/mcp-server-entry.js`) |
+| `memory`, `maas` | commander aliases for the root program (not package.json bins) |
+
+### Global options (apply to all commands)
+
+| Option | Meaning |
+|---|---|
+| `-h, --help` | show command help |
+| `-V, --version` | show version |
+| `-v, --verbose` | verbose logging |
+| `--api-url <url>` | override API base URL |
+| `--output <format>` | `table` (default) \| `json` \| `yaml` |
+| `--no-mcp` | disable MCP route, use direct API |
+
+> ⚠️ **Pitfall — do NOT use `--no-mcp` for memory operations.** Verified live: `--no-mcp` forces `baseURL` to `https://api.lanonasis.com` (the vendor AI proxy), which returns an empty HTML page for `/api/v1/memories/<id>` — the CLI surfaces this as `Request failed with status code 500`. The default route sends memory ops to `https://mcp.lanonasis.com/api/v1/memory/<id>` (the real memory service). Source: `src/utils/api.ts:638-640` ("api.lanonasis.com is the vendor AI proxy, NOT the memory service. Memory operations must go to mcp.lanonasis.com."). `--no-mcp` is only meaningful for non-memory service commands.
+
+### Top-level commands
+
+| Command | Alias | Purpose |
+|---|---|---|
+| `init` | | initialize CLI configuration |
+| `auth` | `login` | authentication: `login`, `logout`, `status`, `diagnose` |
+| `mcp` | | MCP server/client ops: `init`, `connect`, `disconnect`, `status`, `tools`, `call`, `config`, `server`, `diagnose` |
+| `memory` | `mem` | memory CRUD + sessions + intelligence (see below) |
+| `repl` | | lightweight REPL for memory ops (`--mcp`, `--api`, `--ai-router`, `--token`, `--model`, `--config`) |
+| `topic` | `topics` | topic management: `create`, `list`, `get`, `update`, `delete` |
+| `config` | | config management: `set`, `get`, `show`, `list`, `set-api-url`, `test`, `discover`, `endpoints`, `set-override`, `clear-overrides`, `validate`, `backup`, `restore`, `reset` |
+| `org` | `organization` | organization management |
+| `api-keys` | `keys` | API keys: `project create/list`, `create/list/get/update/delete`, `mcp register-tool/list-tools/request-access`, `usage` |
+| `prescan` | | secret/PII scan: `run <path>` (`--save`, `--ci`, `--fail-on`), `status`, `audit <file>`, `safe <file>` |
+| `completion` | | shell completions |
+| `dashboard` | `dash` | interactive dashboard |
+| `documentation` | `doc` | documentation |
+| `sdk` | | SDK info/generation |
+| `api` | `rest` | direct REST operations |
+| `deploy` | `deployment` | deployment orchestration |
+| `service` | `services` | service management |
+| `status` | | overall status |
+| `whoami` | | current identity |
+| `health` | `check` | comprehensive health check (`--verbose`) |
+| `docs` | | docs access |
+
+### `memory` subcommands
+
+| Subcommand | Alias | Key options |
+|---|---|---|
+| `create` | `add` | `-t/--title`, `-c/--content`, `--type`, `--tags`, `--topic-id`, `-i/--interactive`, `--json <json>` (title, content, type/memory_type, tags[], topic_id), `--content-file <path>` |
+| `save-session` | | `-t/--title` (default `Session summary`), `--type` (default `project`), `--tags`, `--test-summary` |
+| `list-sessions` | | `-p/--page`, `-l/--limit`, `--type`, `--tags`, `--sort`, `--order` |
+| `load-session` | | `<id>` |
+| `delete-session` | | `<id>`, `-f/--force` |
+| `list` | `ls` | `-p/--page`, `-l/--limit`, `--type`, `--tags`, `--user-id`, `--sort`, `--order` |
+| `search` | | `<query...>`, `-l/--limit`, `--threshold`, `--type`, `--tags`, `--fallback-mode`, `--no-fallback`, `--fail-on-fallback`, `--ci`, `--json` |
+| `get` | `show` | `<id>` |
+| `update` | | `<id>`, `-t/--title`, `-c/--content`, `--type`, `--tags`, `-i/--interactive` |
+| `delete` | `rm` | `<id>`, `-f/--force` |
+| `stats` | | memory statistics |
+| `intelligence` | | `health`, `suggest-tags <memory-id>`, `related <memory-id>`, `detect-duplicates` (shared: `--organization-id`, `--topic-id`, `--scope`, `--json`) |
+
+### Field naming contract — `memory_type` vs `type`
+
+- **Wire format is `memory_type`.** The CLI REST client (`src/utils/api.ts`), the MaaS REST server schema (`src/types/memory-aligned.ts`), and the CLI MCP server (`src/mcp/server/lanonasis-server.ts`) all use `memory_type`.
+- **`type` is only an alias at the Supabase Edge Function layer**: `memory-create` (`const memoryType = body.memory_type || body.type`) and `memory-search` (`url.searchParams.get("type")`).
+- CLI input (`--type` flag or `--json '{"type": ...}'`) is coerced to `memory_type` before it is sent.
+- On create/update/list the CLI sends **both** `memory_type` and `type` (alias) so the type persists and the list filter applies regardless of which gateway/schema layer is live (`src/utils/api.ts` `withTypeAlias`).
+- Search responses may return `type` on the row; the CLI normalizes to `memory_type` (`src/commands/memory.ts:1170`).
 
 ## 🔍 Secret Prescan (v3.10.1+)
 

--- a/cli/SKILL.md
+++ b/cli/SKILL.md
@@ -31,6 +31,47 @@ node dist/index.js config
 npm pack --dry-run
 ```
 
+## Usage guide (agent-facing)
+
+This is the command surface an AI agent needs to drive the published CLI. It is derived from `cli/src/index.ts` + `cli/src/commands/*`; when in doubt, run `node dist/index.js <cmd> -h` and trust that over this summary.
+
+### Binaries
+
+- `lanonasis` (canonical), `onasis`, `lanonasis-mcp` — actual package.json bins.
+- `memory`, `maas` — commander root aliases, NOT package.json bins.
+
+### Global options
+
+- `-h, --help`, `-V, --version`, `-v, --verbose`
+- `--api-url <url>` — override API base URL
+- `--output <format>` — `table` (default) | `json` | `yaml`
+- `--no-mcp` — disable MCP route, use direct API
+
+> ⚠️ **Do NOT use `--no-mcp` for memory operations.** Verified live (2026-08-03): `--no-mcp` sets `forceDirectApi`, which forces `baseURL` to `config.getApiUrl()` → default `https://api.lanonasis.com` (the vendor AI proxy). That host returns an empty HTML page for `/api/v1/memories/<id>` → CLI error `Request failed with status code 500`. Memory ops must stay on the default MCP route → `https://mcp.lanonasis.com/api/v1/memory/<id>` (real memory service, returns JSON). Source anchor: `cli/src/utils/api.ts:638-640`.
+
+### Top-level commands
+
+`init`, `auth` (login/logout/status/diagnose), `mcp` (init/connect/disconnect/status/tools/call/config/server/diagnose), `memory` (alias `mem`), `repl`, `topic` (alias `topics`), `config`, `org` (alias `organization`), `api-keys` (alias `keys`), `prescan`, `completion`, `dashboard` (alias `dash`), `documentation` (alias `doc`), `sdk`, `api` (alias `rest`), `deploy` (alias `deployment`), `service` (alias `services`), `status`, `whoami`, `health` (alias `check`), `docs`.
+
+### `memory` subcommands
+
+- `create` (alias `add`) — `-t/--title`, `-c/--content`, `--type`, `--tags`, `--topic-id`, `-i/--interactive`, `--json <json>` (accepts title, content, type/memory_type, tags[], topic_id), `--content-file <path>`
+- `save-session` — `-t/--title` (default `Session summary`), `--type` (default `project`), `--tags`, `--test-summary`
+- `list-sessions` — `-p/--page`, `-l/--limit`, `--type`, `--tags`, `--sort`, `--order`
+- `load-session <id>`, `delete-session <id>` (`-f/--force`)
+- `list` (alias `ls`) — `-p/--page`, `-l/--limit`, `--type`, `--tags`, `--user-id`, `--sort`, `--order`
+- `search <query...>` — `-l/--limit`, `--threshold`, `--type`, `--tags`, `--fallback-mode`, `--no-fallback`, `--fail-on-fallback`, `--ci`, `--json`
+- `get` (alias `show`) `<id>`, `update <id>`, `delete` (alias `rm`) `<id>`
+- `stats`
+- `intelligence` — `health`, `suggest-tags <memory-id>`, `related <memory-id>`, `detect-duplicates` (shared: `--organization-id`, `--topic-id`, `--scope`, `--json`)
+
+### Field naming contract (`memory_type` vs `type`)
+
+- Wire format is **`memory_type`** everywhere the CLI talks to MaaS: REST client `cli/src/utils/api.ts`, server schema `src/types/memory-aligned.ts`, CLI MCP server `cli/src/mcp/server/lanonasis-server.ts`, mem-intel-sdk MCP server.
+- `type` is accepted as an **alias only by the Supabase Edge Function layer**: `memory-create` (`body.memory_type || body.type`) and `memory-search` (`url.searchParams.get("type")`).
+- The CLI `--type` flag / `--json '{"type": ...}'` input is coerced to `memory_type` before send (`cli/src/commands/memory.ts:681-690`).
+- Search rows may come back with `type`; the CLI normalizes to `memory_type` (`cli/src/commands/memory.ts:1170`).
+
 ## Package boundaries
 
 - Main CLI package: `cli/`, published as `@lanonasis/cli`.
@@ -96,6 +137,8 @@ Check these first during audits:
 - Prescan docs versus `cli/src/commands/prescan.ts` and bundled `@lanonasis/secret-prescan`.
 - Auth examples versus `cli/src/commands/auth.ts` and `cli/src/utils/config.ts`.
 - Global installed binaries versus local `dist/` output; do not treat stale global installs as source of truth.
+- `--no-mcp` + memory commands: memory ops are never routed to `api.lanonasis.com` (vendor AI proxy → 500); they always stay on `mcp.lanonasis.com` (memory service), even under `--no-mcp` / `forceApi`. `--no-mcp` only affects non-memory endpoints. Do not document `--no-mcp` as a memory-command escape hatch.
+- `memory_type` vs `type`: wire format is `memory_type`; `type` is an alias only on the Supabase EF layer. The CLI sends BOTH `memory_type` and `type` on create/update/list so the deployed gateway (which persists via `type`) and the MaaS schema (which reads `memory_type`) both apply the value. Do not send `type` INSTEAD of `memory_type`.
 
 ## Safety
 

--- a/cli/dist/utils/api.d.ts
+++ b/cli/dist/utils/api.d.ts
@@ -207,6 +207,7 @@ export declare class APIClient {
     constructor();
     login(email: string, password: string): Promise<AuthResponse>;
     register(email: string, password: string, organizationName?: string): Promise<AuthResponse>;
+    private withTypeAlias;
     createMemory(data: CreateMemoryRequest): Promise<MemoryEntry>;
     getMemories(params?: GetMemoriesParams): Promise<PaginatedResponse<MemoryEntry>>;
     getMemory(id: string): Promise<MemoryEntry>;

--- a/cli/dist/utils/api.js
+++ b/cli/dist/utils/api.js
@@ -377,20 +377,26 @@ export class APIClient {
             }
             // Determine the correct API base URL:
             // - Auth endpoints -> auth.lanonasis.com
-            // - Memory/MCP operations (JWT or vendor key) -> mcp.lanonasis.com (the memory service)
+            // - Memory operations -> mcp.lanonasis.com (the memory service)
             // - Other direct API calls -> api.lanonasis.com (vendor AI proxy)
+            //
+            // NOTE: memory endpoints are intentionally NOT part of forceDirectApi.
+            // api.lanonasis.com is the vendor AI proxy, NOT the memory service, and
+            // routing memory ops there returns 500. `--no-mcp` / forceApi disables
+            // the MCP auto-connect and routes *non-memory* endpoints to the vendor
+            // proxy, but memory operations MUST always go to mcp.lanonasis.com.
             let apiBaseUrl;
-            const useMcpServer = !forceDirectApi && !isAuthEndpoint && (prefersTokenAuth || useVendorKeyAuth || isMemoryEndpoint);
+            const useMcpServer = !isAuthEndpoint && (isMemoryEndpoint || (!forceDirectApi && (prefersTokenAuth || useVendorKeyAuth)));
             if (isAuthEndpoint || isAuthGatewayManagementEndpoint) {
                 apiBaseUrl = discoveredServices?.auth_base || 'https://auth.lanonasis.com';
-            }
-            else if (forceDirectApi) {
-                // Explicit force: direct to api.lanonasis.com for troubleshooting.
-                apiBaseUrl = this.config.getApiUrl();
             }
             else if (useMcpServer) {
                 // Memory service lives at mcp.lanonasis.com — accepts JWT, OAuth, and vendor keys.
                 apiBaseUrl = 'https://mcp.lanonasis.com/api/v1';
+            }
+            else if (forceDirectApi) {
+                // Explicit force: direct to api.lanonasis.com for troubleshooting.
+                apiBaseUrl = this.config.getApiUrl();
             }
             else {
                 apiBaseUrl = this.config.getApiUrl();
@@ -436,7 +442,7 @@ export class APIClient {
             // Add project scope for Golden Contract compliance
             config.headers['X-Project-Scope'] = 'lanonasis-maas';
             if (process.env.CLI_VERBOSE === 'true') {
-                const transportMode = forceDirectApi ? 'api-forced' : (useMcpServer ? 'mcp-http' : 'api');
+                const transportMode = useMcpServer ? 'mcp-http' : (forceDirectApi ? 'api-forced' : 'api');
                 config.headers['X-Transport-Mode'] = transportMode;
                 console.log(chalk.dim(`→ ${config.method?.toUpperCase()} ${config.url} [${requestId}]`));
                 console.log(chalk.dim(`  transport=${transportMode} baseURL=${config.baseURL}`));
@@ -525,13 +531,29 @@ export class APIClient {
     }
     // Memory operations - aligned with REST API canonical endpoints
     // All memory endpoints use /api/v1/memories path (plural, per REST conventions)
+    //
+    // NOTE: The deployed memory gateway (mcp.lanonasis.com) persists the type via
+    // the `type` field, while the MaaS schema and Supabase edge functions accept
+    // `memory_type` (and `type` as an alias). To make the type persist across every
+    // gateway/schema layer we send BOTH `memory_type` and `type` on create/update.
+    withTypeAlias(payload) {
+        const memoryType = payload.memory_type;
+        if (memoryType === undefined) {
+            return payload;
+        }
+        return { ...payload, type: memoryType };
+    }
     async createMemory(data) {
-        const response = await this.client.post('/api/v1/memories', data);
+        const response = await this.client.post('/api/v1/memories', this.withTypeAlias(data));
         return this.normalizeMemoryEntry(response.data);
     }
     async getMemories(params = {}) {
+        // The deployed memory gateway filters the list via the `type` query param
+        // while the MaaS schema accepts `memory_type` (and `type` alias). Send both
+        // so the filter applies regardless of which gateway/schema layer is live.
+        const requestParams = this.withTypeAlias(params);
         try {
-            const response = await this.client.get('/api/v1/memories', { params });
+            const response = await this.client.get('/api/v1/memories', { params: requestParams });
             return response.data;
         }
         catch (error) {
@@ -547,6 +569,7 @@ export class APIClient {
                 };
                 if (params.memory_type) {
                     listPayload.memory_type = params.memory_type;
+                    listPayload.type = params.memory_type;
                 }
                 if (params.tags) {
                     listPayload.tags = Array.isArray(params.tags)
@@ -707,14 +730,14 @@ export class APIClient {
     async updateMemory(id, data) {
         const resolvedId = await this.resolveMemoryId(id);
         try {
-            const response = await this.client.put(`/api/v1/memories/${encodeURIComponent(resolvedId)}`, data);
+            const response = await this.client.put(`/api/v1/memories/${encodeURIComponent(resolvedId)}`, this.withTypeAlias(data));
             return this.normalizeMemoryEntry(response.data);
         }
         catch (error) {
             if (this.shouldUseLegacyMemoryRpcFallback(error) || error?.response?.status === 404) {
                 const fallback = await this.client.post('/api/v1/memory/update', {
                     id: resolvedId,
-                    ...data
+                    ...this.withTypeAlias(data)
                 });
                 const payload = fallback.data && typeof fallback.data === 'object'
                     ? fallback.data.data ?? fallback.data

--- a/cli/src/__tests__/api-client-auth-header.test.ts
+++ b/cli/src/__tests__/api-client-auth-header.test.ts
@@ -120,12 +120,12 @@ describe('APIClient authentication headers', () => {
     const handler = requestHandlers[0];
     const updated = await handler({
       headers: {},
-      url: '/api/v1/memories/search',
-      method: 'post'
+      url: '/api/v1/topics',
+      method: 'get'
     });
 
     expect(updated.baseURL).toBe('https://api.example.com');
-    expect(updated.url).toBe('/api/v1/memories/search');
+    expect(updated.url).toBe('/api/v1/topics');
     expect(updated.headers.Authorization).toBe('Bearer oauth-token-xyz');
     expect(updated.headers['X-Auth-Method']).toBe('jwt');
   });
@@ -150,8 +150,8 @@ describe('APIClient authentication headers', () => {
     const handler = requestHandlers[0];
     const updated = await handler({
       headers: {},
-      url: '/api/v1/memories/search',
-      method: 'post'
+      url: '/api/v1/topics',
+      method: 'get'
     });
 
     expect(updated.baseURL).toBe('https://api.example.com');

--- a/cli/src/__tests__/api-client-transport-split.test.ts
+++ b/cli/src/__tests__/api-client-transport-split.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+// Regression test for the transport-mode split:
+//   - Memory operations ALWAYS go to mcp.lanonasis.com (the memory service),
+//     even when --no-mcp / forceApi / LANONASIS_FORCE_API is set.
+//   - Non-memory direct-API calls honor forceApi and go to config.getApiUrl().
+//   - api.lanonasis.com (the vendor AI proxy) must NEVER receive memory ops.
+//   - create/update/list send BOTH `memory_type` and `type` so the deployed
+//     gateway (which persists via `type`) and the MaaS schema (which reads
+//     `memory_type`) both apply the filter/type.
+//
+// See https://github.com/lanonasis/lanonasis-maas bug: "--no-mcp routes memory
+// ops to api.lanonasis.com -> 500; --type not persisting on create/update".
+
+const requestHandlers: Array<(config: any) => any> = [];
+
+const mockAxiosInstance = {
+  interceptors: {
+    request: {
+      use: jest.fn((fulfilled) => {
+        requestHandlers.push(fulfilled);
+      })
+    },
+    response: {
+      use: jest.fn()
+    }
+  },
+  defaults: {},
+  get: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+  delete: jest.fn()
+};
+
+jest.unstable_mockModule('axios', () => ({
+  default: {
+    create: jest.fn(() => mockAxiosInstance),
+  },
+  create: jest.fn(() => mockAxiosInstance),
+}));
+
+const { APIClient } = await import('../utils/api.js');
+
+function stubConfig(client: APIClient, overrides: Record<string, unknown> = {}) {
+  const config = (client as any).config;
+  config.init = jest.fn().mockResolvedValue(undefined);
+  config.refreshTokenIfNeeded = jest.fn().mockResolvedValue(undefined);
+  config.discoverServices = jest.fn().mockResolvedValue(undefined);
+  config.get = jest.fn((key: string) => {
+    const defaults: Record<string, unknown> = {
+      discoveredServices: { auth_base: 'https://auth.example.com' },
+      authMethod: 'jwt',
+      forceApi: false,
+      connectionTransport: 'auto',
+    };
+    return overrides[key] !== undefined ? overrides[key] : defaults[key];
+  });
+  config.getApiUrl = jest.fn().mockReturnValue('https://api.example.com');
+  config.getToken = jest.fn().mockReturnValue('jwt-token-abc');
+  config.getVendorKeyAsync = jest.fn().mockResolvedValue(undefined);
+  return config;
+}
+
+async function runInterceptor(config: any) {
+  const handler = requestHandlers[0];
+  return handler({
+    headers: {},
+    url: config.url,
+    method: config.method || 'get',
+    params: config.params,
+  });
+}
+
+describe('APIClient transport-mode split (memory vs direct API)', () => {
+  beforeEach(() => {
+    requestHandlers.length = 0;
+    mockAxiosInstance.interceptors.request.use.mockClear();
+    mockAxiosInstance.interceptors.response.use.mockClear();
+    mockAxiosInstance.get.mockReset();
+    mockAxiosInstance.post.mockReset();
+    mockAxiosInstance.put.mockReset();
+    mockAxiosInstance.delete.mockReset();
+    delete process.env.LANONASIS_FORCE_API;
+    delete process.env.CLI_FORCE_API;
+    delete process.env.ONASIS_FORCE_API;
+  });
+
+  it('routes memory endpoints to mcp.lanonasis.com by default (JWT)', async () => {
+    const client = new APIClient();
+    stubConfig(client, { authMethod: 'jwt' });
+
+    const updated = await runInterceptor({ url: '/api/v1/memories', method: 'get' });
+
+    expect(updated.baseURL).toBe('https://mcp.lanonasis.com/api/v1');
+    expect(updated.url).toBe('/memory');
+  });
+
+  it('keeps memory endpoints on mcp.lanonasis.com even when forceApi config is set (--no-mcp path)', async () => {
+    const client = new APIClient();
+    stubConfig(client, { forceApi: true, connectionTransport: 'api' });
+
+    const updated = await runInterceptor({ url: '/api/v1/memories', method: 'get' });
+
+    // Regression: memory ops must NEVER be routed to api.lanonasis.com (vendor proxy -> 500).
+    expect(updated.baseURL).toBe('https://mcp.lanonasis.com/api/v1');
+    expect(updated.url).toBe('/memory');
+    expect(updated.baseURL).not.toContain('api.lanonasis.com');
+  });
+
+  it('keeps memory endpoints on mcp.lanonasis.com when LANONASIS_FORCE_API env is set', async () => {
+    process.env.LANONASIS_FORCE_API = 'true';
+    const client = new APIClient();
+    stubConfig(client, { forceApi: false, connectionTransport: 'auto' });
+
+    const updated = await runInterceptor({ url: '/api/v1/memories', method: 'get' });
+
+    expect(updated.baseURL).toBe('https://mcp.lanonasis.com/api/v1');
+    expect(updated.baseURL).not.toContain('api.lanonasis.com');
+  });
+
+  it('keeps a single-memory GET on mcp.lanonasis.com under forceApi (memory get --no-mcp)', async () => {
+    const client = new APIClient();
+    stubConfig(client, { forceApi: true, connectionTransport: 'api' });
+
+    const updated = await runInterceptor({ url: '/api/v1/memories/mem_123', method: 'get' });
+
+    expect(updated.baseURL).toBe('https://mcp.lanonasis.com/api/v1');
+    expect(updated.url).toBe('/memory/mem_123');
+    expect(updated.baseURL).not.toContain('api.lanonasis.com');
+  });
+
+  it('keeps memory search on mcp.lanonasis.com under forceApi', async () => {
+    const client = new APIClient();
+    stubConfig(client, { forceApi: true, connectionTransport: 'api' });
+
+    const updated = await runInterceptor({ url: '/api/v1/memories/search', method: 'post' });
+
+    expect(updated.baseURL).toBe('https://mcp.lanonasis.com/api/v1');
+    expect(updated.url).toBe('/memory/search');
+    expect(updated.baseURL).not.toContain('api.lanonasis.com');
+  });
+
+  it('routes non-memory endpoints to config.getApiUrl() when forceApi is set', async () => {
+    const client = new APIClient();
+    stubConfig(client, { forceApi: true, connectionTransport: 'api' });
+
+    const updated = await runInterceptor({ url: '/api/v1/topics', method: 'get' });
+
+    expect(updated.baseURL).toBe('https://api.example.com');
+    expect(updated.url).toBe('/api/v1/topics');
+  });
+
+  it('routes auth endpoints to auth_base regardless of forceApi', async () => {
+    const client = new APIClient();
+    stubConfig(client, { forceApi: true, connectionTransport: 'api' });
+
+    const updated = await runInterceptor({ url: '/v1/auth/me', method: 'get' });
+
+    expect(updated.baseURL).toBe('https://auth.example.com');
+  });
+
+  it('createMemory sends BOTH memory_type and type so the type persists on the deployed gateway', async () => {
+    const client = new APIClient();
+    stubConfig(client, { authMethod: 'jwt' });
+    mockAxiosInstance.post.mockResolvedValue({
+      data: {
+        id: 'mem_1',
+        title: 'T',
+        content: 'C',
+        memory_type: 'project',
+        tags: [],
+        user_id: 'u1',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+        access_count: 0,
+      }
+    });
+
+    const created = await client.createMemory({ title: 'T', content: 'C', memory_type: 'project' });
+
+    expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+      '/api/v1/memories',
+      expect.objectContaining({ memory_type: 'project', type: 'project' })
+    );
+    expect(created.memory_type).toBe('project');
+  });
+
+  it('updateMemory sends BOTH memory_type and type', async () => {
+    const client = new APIClient();
+    stubConfig(client, { authMethod: 'jwt' });
+    mockAxiosInstance.put.mockResolvedValue({
+      data: {
+        id: 'mem_1',
+        title: 'T',
+        content: 'C',
+        memory_type: 'project',
+        tags: [],
+        user_id: 'u1',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+        access_count: 0,
+      }
+    });
+
+    await client.updateMemory('8f14e45f-ceea-4a4b-9a2c-1f0b9c2d3e4a', { memory_type: 'project' });
+
+    expect(mockAxiosInstance.put).toHaveBeenCalledWith(
+      '/api/v1/memories/8f14e45f-ceea-4a4b-9a2c-1f0b9c2d3e4a',
+      expect.objectContaining({ memory_type: 'project', type: 'project' })
+    );
+  });
+
+  it('getMemories sends BOTH memory_type and type query params so the type filter applies', async () => {
+    const client = new APIClient();
+    stubConfig(client, { authMethod: 'jwt' });
+    mockAxiosInstance.get.mockResolvedValue({
+      data: { data: [], memories: [], pagination: { total: 0, limit: 20, offset: 0 } }
+    });
+
+    await client.getMemories({ page: 1, limit: 20, memory_type: 'project' });
+
+    expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+      '/api/v1/memories',
+      expect.objectContaining({
+        params: expect.objectContaining({ memory_type: 'project', type: 'project' })
+      })
+    );
+  });
+
+  it('withTypeAlias leaves payloads without memory_type untouched', async () => {
+    const client = new APIClient();
+    stubConfig(client, { authMethod: 'jwt' });
+    mockAxiosInstance.get.mockResolvedValue({
+      data: { data: [], memories: [], pagination: { total: 0, limit: 20, offset: 0 } }
+    });
+
+    await client.getMemories({ page: 1, limit: 20 });
+
+    expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+      '/api/v1/memories',
+      expect.objectContaining({
+        params: { page: 1, limit: 20 }
+      })
+    );
+  });
+});

--- a/cli/src/utils/api.ts
+++ b/cli/src/utils/api.ts
@@ -650,19 +650,25 @@ export class APIClient {
 
       // Determine the correct API base URL:
       // - Auth endpoints -> auth.lanonasis.com
-      // - Memory/MCP operations (JWT or vendor key) -> mcp.lanonasis.com (the memory service)
+      // - Memory operations -> mcp.lanonasis.com (the memory service)
       // - Other direct API calls -> api.lanonasis.com (vendor AI proxy)
+      //
+      // NOTE: memory endpoints are intentionally NOT part of forceDirectApi.
+      // api.lanonasis.com is the vendor AI proxy, NOT the memory service, and
+      // routing memory ops there returns 500. `--no-mcp` / forceApi disables
+      // the MCP auto-connect and routes *non-memory* endpoints to the vendor
+      // proxy, but memory operations MUST always go to mcp.lanonasis.com.
       let apiBaseUrl: string;
-      const useMcpServer = !forceDirectApi && !isAuthEndpoint && (prefersTokenAuth || useVendorKeyAuth || isMemoryEndpoint);
+      const useMcpServer = !isAuthEndpoint && (isMemoryEndpoint || (!forceDirectApi && (prefersTokenAuth || useVendorKeyAuth)));
 
       if (isAuthEndpoint || isAuthGatewayManagementEndpoint) {
         apiBaseUrl = discoveredServices?.auth_base || 'https://auth.lanonasis.com';
-      } else if (forceDirectApi) {
-        // Explicit force: direct to api.lanonasis.com for troubleshooting.
-        apiBaseUrl = this.config.getApiUrl();
       } else if (useMcpServer) {
         // Memory service lives at mcp.lanonasis.com — accepts JWT, OAuth, and vendor keys.
         apiBaseUrl = 'https://mcp.lanonasis.com/api/v1';
+      } else if (forceDirectApi) {
+        // Explicit force: direct to api.lanonasis.com for troubleshooting.
+        apiBaseUrl = this.config.getApiUrl();
       } else {
         apiBaseUrl = this.config.getApiUrl();
       }
@@ -710,7 +716,7 @@ export class APIClient {
       config.headers['X-Project-Scope'] = 'lanonasis-maas';
       
       if (process.env.CLI_VERBOSE === 'true') {
-        const transportMode = forceDirectApi ? 'api-forced' : (useMcpServer ? 'mcp-http' : 'api');
+        const transportMode = useMcpServer ? 'mcp-http' : (forceDirectApi ? 'api-forced' : 'api');
         config.headers['X-Transport-Mode'] = transportMode;
         console.log(chalk.dim(`→ ${config.method?.toUpperCase()} ${config.url} [${requestId}]`));
         console.log(chalk.dim(`  transport=${transportMode} baseURL=${config.baseURL}`));
@@ -823,14 +829,31 @@ export class APIClient {
 
   // Memory operations - aligned with REST API canonical endpoints
   // All memory endpoints use /api/v1/memories path (plural, per REST conventions)
+  //
+  // NOTE: The deployed memory gateway (mcp.lanonasis.com) persists the type via
+  // the `type` field, while the MaaS schema and Supabase edge functions accept
+  // `memory_type` (and `type` as an alias). To make the type persist across every
+  // gateway/schema layer we send BOTH `memory_type` and `type` on create/update.
+  private withTypeAlias<T extends object>(payload: T): T & { type?: string } {
+    const memoryType = (payload as { memory_type?: unknown }).memory_type;
+    if (memoryType === undefined) {
+      return payload as T & { type?: string };
+    }
+    return { ...payload, type: memoryType } as T & { type?: string };
+  }
+
   async createMemory(data: CreateMemoryRequest): Promise<MemoryEntry> {
-    const response = await this.client.post('/api/v1/memories', data);
+    const response = await this.client.post('/api/v1/memories', this.withTypeAlias(data));
     return this.normalizeMemoryEntry(response.data);
   }
 
   async getMemories(params: GetMemoriesParams = {}): Promise<PaginatedResponse<MemoryEntry>> {
+    // The deployed memory gateway filters the list via the `type` query param
+    // while the MaaS schema accepts `memory_type` (and `type` alias). Send both
+    // so the filter applies regardless of which gateway/schema layer is live.
+    const requestParams = this.withTypeAlias(params);
     try {
-      const response = await this.client.get('/api/v1/memories', { params });
+      const response = await this.client.get('/api/v1/memories', { params: requestParams });
       return response.data;
     } catch (error: any) {
       // Backward-compatible fallback: newer API contracts may reject GET list.
@@ -846,6 +869,7 @@ export class APIClient {
         };
         if (params.memory_type) {
           listPayload.memory_type = params.memory_type;
+          listPayload.type = params.memory_type;
         }
         if (params.tags) {
           listPayload.tags = Array.isArray(params.tags)
@@ -1016,13 +1040,13 @@ export class APIClient {
     const resolvedId = await this.resolveMemoryId(id);
 
     try {
-      const response = await this.client.put(`/api/v1/memories/${encodeURIComponent(resolvedId)}`, data);
+      const response = await this.client.put(`/api/v1/memories/${encodeURIComponent(resolvedId)}`, this.withTypeAlias(data));
       return this.normalizeMemoryEntry(response.data);
     } catch (error: any) {
       if (this.shouldUseLegacyMemoryRpcFallback(error) || error?.response?.status === 404) {
         const fallback = await this.client.post('/api/v1/memory/update', {
           id: resolvedId,
-          ...data
+          ...this.withTypeAlias(data)
         });
         const payload = fallback.data && typeof fallback.data === 'object'
           ? (fallback.data as Record<string, unknown>).data ?? fallback.data


### PR DESCRIPTION
## Summary
- keep all memory endpoints on `mcp.lanonasis.com` even when `--no-mcp` / `forceApi` is set, so `lanonasis memory get <id> --no-mcp` no longer routes to the vendor proxy (`api.lanonasis.com`) and 500s
- send both `memory_type` and `type` on memory create/update/list to preserve type persistence/filtering across the deployed gateway + MaaS schema split
- add regression coverage for the transport-mode split and update agent-facing docs to match the live contract

## Verification
- `node --experimental-vm-modules node_modules/jest/bin/jest.js src/__tests__/api-client-auth-header.test.ts src/__tests__/api-client-transport-split.test.ts`
- `node --experimental-vm-modules node_modules/jest/bin/jest.js src/__tests__/api-client-auth-header.test.ts src/__tests__/api-client-transport-split.test.ts src/__tests__/api-client-memory-stats.test.ts src/__tests__/api-client-memory-prefix.test.ts src/__tests__/memory-search-fallback.test.ts src/__tests__/api-consumer.test.ts`
- `npm run build`
- `npx tsc -p tsconfig.json --noEmit`

## Notes
- Baseline unrelated failures remain in this repo's broader suite (`src/__tests__/auth-persistence.test.ts` and existing long-running integration/load tests); this PR does not modify those paths.
