### PR TITLE
fix(cli): reset stale bearer state and refresh profile on vendor-key login (monorepo gh#190)

### DIFF
--- a/cli/src/__tests__/auth-command-vendor-login.test.ts
+++ b/cli/src/__tests__/auth-command-vendor-login.test.ts
@@ -75,7 +75,11 @@ describe('loginCommand vendor-key path', () => {
   });
 
   afterEach(async () => {
-    process.env.HOME = previousHome;
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
     if (previousSkipValidation === undefined) {
       delete process.env.SKIP_SERVER_VALIDATION;
     } else {

--- a/cli/src/__tests__/auth-command-vendor-login.test.ts
+++ b/cli/src/__tests__/auth-command-vendor-login.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Vendor-key login command regression tests.
+ *
+ * Covers the bug where explicit vendor-key auth inherited stale OAuth/JWT
+ * session state and could keep showing the wrong cached account.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import * as fsPromises from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+const mockHealthGet = jest.fn();
+const mockGetUserProfile = jest.fn();
+
+jest.unstable_mockModule('../utils/api.js', () => ({
+  apiClient: {
+    get: mockHealthGet,
+  },
+  APIClient: class MockAPIClient {
+    noExit = false;
+
+    async getUserProfile() {
+      return mockGetUserProfile();
+    }
+  },
+}));
+
+jest.unstable_mockModule('ora', () => ({
+  default: () => ({
+    start: () => ({
+      succeed: jest.fn(),
+      fail: jest.fn(),
+      start: jest.fn(),
+      stop: jest.fn(),
+      text: '',
+    }),
+  }),
+}));
+
+const { loginCommand } = await import('../commands/auth.js');
+const { CLIConfig } = await import('../utils/config.js');
+
+describe('loginCommand vendor-key path', () => {
+  let tempHome: string;
+  let previousHome: string | undefined;
+  let previousSkipValidation: string | undefined;
+
+  beforeEach(async () => {
+    previousHome = process.env.HOME;
+    previousSkipValidation = process.env.SKIP_SERVER_VALIDATION;
+
+    tempHome = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'lanonasis-auth-command-'));
+    process.env.HOME = tempHome;
+    process.env.SKIP_SERVER_VALIDATION = 'true';
+
+    mockHealthGet.mockReset();
+    mockGetUserProfile.mockReset();
+    mockHealthGet.mockResolvedValue({ status: 200, data: { status: 'ok' } });
+    mockGetUserProfile.mockResolvedValue({
+      id: 'user-admin-1',
+      email: 'admin@lanonasis.com',
+      name: 'Admin User',
+      avatar_url: null,
+      organization_id: 'org-admin',
+      role: 'admin',
+      plan: 'enterprise',
+      provider: 'vendor_key',
+      project_scope: 'lanonasis-maas',
+      platform: 'cli',
+      created_at: null,
+      last_sign_in_at: null,
+      metadata: { locale: null, timezone: null },
+    });
+  });
+
+  afterEach(async () => {
+    process.env.HOME = previousHome;
+    if (previousSkipValidation === undefined) {
+      delete process.env.SKIP_SERVER_VALIDATION;
+    } else {
+      process.env.SKIP_SERVER_VALIDATION = previousSkipValidation;
+    }
+
+    await fsPromises.rm(tempHome, { recursive: true, force: true });
+  });
+
+  it('clears stale bearer-session fields and refreshes the cached profile for explicit vendor-key auth', async () => {
+    const staleConfig = new CLIConfig();
+    await staleConfig.init();
+    await staleConfig.setToken('stale-oauth-token');
+    staleConfig.set('refresh_token', 'stale-refresh-token');
+    staleConfig.set('token_expires_at', Date.now() + 60_000);
+    staleConfig.set('tokenExpiry', Math.floor(Date.now() / 1000) + 60);
+    staleConfig.set('authMethod', 'oauth');
+    staleConfig.set('user', {
+      email: 'info@lanonasis.com',
+      organization_id: 'org-info',
+      role: 'viewer',
+      plan: 'free',
+    });
+    await staleConfig.save();
+
+    await loginCommand({ vendorKey: 'pk_test_explicit_vendor_key' });
+
+    const reloadedConfig = new CLIConfig();
+    await reloadedConfig.init();
+
+    expect(reloadedConfig.get('authMethod')).toBe('vendor_key');
+    expect(reloadedConfig.getToken()).toBeUndefined();
+    expect(reloadedConfig.get('refresh_token')).toBeUndefined();
+    expect(reloadedConfig.get('token_expires_at')).toBeUndefined();
+    expect(reloadedConfig.get('tokenExpiry')).toBeUndefined();
+
+    const currentUser = await reloadedConfig.getCurrentUser();
+    expect(currentUser?.email).toBe('admin@lanonasis.com');
+    expect(currentUser?.organization_id).toBe('org-admin');
+    expect(currentUser?.role).toBe('admin');
+    expect(currentUser?.plan).toBe('enterprise');
+
+    expect(mockGetUserProfile).toHaveBeenCalledTimes(1);
+    expect(mockHealthGet).toHaveBeenCalledWith('/health');
+    expect(await reloadedConfig.getVendorKeyAsync()).toBe('pk_test_explicit_vendor_key');
+  });
+});

--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -6,7 +6,7 @@ import crypto from 'crypto';
 import http from 'http';
 import url from 'url';
 import axios from 'axios';
-import { apiClient } from '../utils/api.js';
+import { APIClient, apiClient } from '../utils/api.js';
 import { CLIConfig } from '../utils/config.js';
 
 // Color scheme
@@ -697,10 +697,28 @@ async function handleVendorKeyAuth(vendorKey: string, config: CLIConfig): Promis
   try {
     await config.setVendorKey(vendorKey);
 
+    // Explicit vendor-key auth should not inherit stale bearer tokens or cached identities
+    // from a previous login session. Keep the process pinned to the intended service key.
+    await config.setAndSave('token', undefined);
+    await config.setAndSave('refresh_token', undefined);
+    await config.setAndSave('token_expires_at', undefined);
+    await config.setAndSave('tokenExpiry', undefined);
+    await config.setAndSave('user', undefined);
+
     // Explicitly set authMethod to vendor_key when user does explicit vendor key auth
-    // This overrides any previous OAuth authMethod
-    await config.set('authMethod', 'vendor_key');
-    await config.save();
+    // This overrides any previous OAuth authMethod.
+    await config.setAndSave('authMethod', 'vendor_key');
+
+    // Resolve the live profile immediately so subsequent status/whoami calls don't fall
+    // back to stale cached emails from a different account.
+    try {
+      const profileClient = new APIClient();
+      profileClient.noExit = true;
+      const profile = await profileClient.getUserProfile();
+      await config.updateCurrentUserProfile(profile as unknown as Record<string, unknown>);
+    } catch {
+      // Best effort only — the vendor key is already validated and should still be usable.
+    }
 
     // Test the vendor key with a health check
     await apiClient.get('/health');

--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -699,15 +699,17 @@ async function handleVendorKeyAuth(vendorKey: string, config: CLIConfig): Promis
 
     // Explicit vendor-key auth should not inherit stale bearer tokens or cached identities
     // from a previous login session. Keep the process pinned to the intended service key.
-    await config.setAndSave('token', undefined);
-    await config.setAndSave('refresh_token', undefined);
-    await config.setAndSave('token_expires_at', undefined);
-    await config.setAndSave('tokenExpiry', undefined);
-    await config.setAndSave('user', undefined);
-
+    // Assign all reset fields in memory, then persist atomically in a single save so an
+    // interrupted write cannot leave a half-cleared session.
+    config.set('token', undefined);
+    config.set('refresh_token', undefined);
+    config.set('token_expires_at', undefined);
+    config.set('tokenExpiry', undefined);
+    config.set('user', undefined);
     // Explicitly set authMethod to vendor_key when user does explicit vendor key auth
     // This overrides any previous OAuth authMethod.
-    await config.setAndSave('authMethod', 'vendor_key');
+    config.set('authMethod', 'vendor_key');
+    await config.save();
 
     // Resolve the live profile immediately so subsequent status/whoami calls don't fall
     // back to stale cached emails from a different account.


### PR DESCRIPTION
## Summary
Fixes the CLI side of monorepo issue thefixer3x/lan-onasis-monorepo#190 — vendor-key auth dying mid-operation and the CLI intermittently resolving `info@lanonasis.com` instead of `admin@lanonasis.com` at session start.

**Root cause:** explicit vendor-key login could inherit stale `token`/`refresh_token`/`user` fields from a prior OAuth/JWT session. That kept the process on a dead refresh path and let `status`/`whoami` report a cached identity from a different account.

## Changes
- `cli/src/commands/auth.ts` `handleVendorKeyAuth`: clear `token`, `refresh_token`, `token_expires_at`, `tokenExpiry`, and `user` before storing the vendor key, so the process stays pinned to the intended service key.
- Set `authMethod=vendor_key` atomically via `setAndSave`.
- Resolve the live profile immediately (`updateCurrentUserProfile`) so subsequent identity calls don't fall back to stale cached emails.
- New regression test: `cli/src/__tests__/auth-command-vendor-login.test.ts` proves stale bearer state is cleared and the cached profile resolves to `admin@lanonasis.com`.

## Test Plan
- `node --experimental-vm-modules node_modules/jest/bin/jest.js src/__tests__/auth-command-vendor-login.test.ts src/__tests__/auth-integration-mocked.test.ts src/__tests__/auth-persistence.test.ts src/__tests__/api-client-auth-header.test.ts` → 4 suites, 36 passed, 2 skipped.
- `tsc --noEmit` → clean.
- Server-side fix (session expiry tied to refresh-token lifetime) lives in thefixer3x/Onasis-CORE PR #98.

Refs thefixer3x/lan-onasis-monorepo#190